### PR TITLE
feat: add using cached results from the db

### DIFF
--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -97,6 +97,7 @@ class SummaryResponseSchema(BaseModel):
 class AnalyzeRequestSchema(BaseModel):
     url: str = Field(description="YouTube video URL")
     focus_prompt: str | None = Field(default=None, max_length=500, description="Optional global focus prompt")
+    force_regenerate: bool = Field(default=False, description="If true, bypass cached run and rerun the LLM pipeline")
 
     @model_validator(mode="after")
     def sanitize_focus_prompt(self) -> "AnalyzeRequestSchema":
@@ -109,6 +110,7 @@ class AnalyzeRequestSchema(BaseModel):
 
 class RegenerateRequestSchema(BaseModel):
     focus_prompt: str | None = Field(default=None, max_length=500, description="Optional updated focus prompt")
+    force_regenerate: bool = Field(default=False, description="If true, bypass cached run and rerun the LLM pipeline")
 
     @model_validator(mode="after")
     def sanitize_focus_prompt(self) -> "RegenerateRequestSchema":

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -11,7 +11,7 @@ import json
 import logging
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_session
@@ -28,6 +28,32 @@ from app.services.youtube import get_transcript_for_video, ingest_video
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+
+async def _find_cached_run(
+    video_id: int,
+    focus_prompt: str | None,
+    session: AsyncSession,
+) -> AnalysisRun | None:
+    """Return the most recent complete run for (video_id, focus_prompt), or None."""
+    if focus_prompt:
+        focus_filter = AnalysisRun.focus_prompt == focus_prompt
+    else:
+        focus_filter = or_(
+            AnalysisRun.focus_prompt.is_(None),
+            AnalysisRun.focus_prompt == "",
+        )
+    result = await session.execute(
+        select(AnalysisRun)
+        .where(
+            AnalysisRun.video_id == video_id,
+            AnalysisRun.status == AnalysisRunStatus.complete,
+            focus_filter,
+        )
+        .order_by(AnalysisRun.id.desc())
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
 
 
 # ---------------------------------------------------------------------------
@@ -81,6 +107,22 @@ async def analyze(
 
     video = result.video
     transcript_source = result.transcript_source
+    quality_warning = result.quality_warning
+
+    # Cache check: return existing complete run unless caller wants a fresh one
+    if not body.force_regenerate:
+        cached_run = await _find_cached_run(video.id, body.focus_prompt, session)
+        if cached_run:
+            logger.info(
+                "Cache hit: returning existing run %d for video %d (focus=%r)",
+                cached_run.id, video.id, body.focus_prompt,
+            )
+            return {
+                "run_id": cached_run.id,
+                "video_id": video.id,
+                "quality_warning": quality_warning,
+                "cached": True,
+            }
 
     # Create the run record so we can return run_id immediately
     from app.models.db import AnalysisRun as Run
@@ -96,7 +138,6 @@ async def analyze(
 
     run_id = run.id
     video_id = video.id
-    quality_warning = result.quality_warning
 
     # Run pipeline in background
     background_tasks.add_task(
@@ -109,6 +150,7 @@ async def analyze(
         "run_id": run_id,
         "video_id": video_id,
         "quality_warning": quality_warning,
+        "cached": False,
     }
 
 
@@ -313,6 +355,16 @@ async def regenerate(
             },
         )
 
+    # Cache check: return existing complete run unless caller wants a fresh one
+    if not body.force_regenerate:
+        cached_run = await _find_cached_run(video_id, body.focus_prompt, session)
+        if cached_run:
+            logger.info(
+                "Cache hit: returning existing run %d for video %d (focus=%r)",
+                cached_run.id, video_id, body.focus_prompt,
+            )
+            return {"run_id": cached_run.id, "video_id": video_id, "cached": True}
+
     # Create new run with updated focus
     run = AnalysisRun(
         video_id=video_id,
@@ -329,7 +381,7 @@ async def regenerate(
         transcript_source_id=transcript_source.id,
     )
 
-    return {"run_id": run.id, "video_id": video_id}
+    return {"run_id": run.id, "video_id": video_id, "cached": False}
 
 
 # ---------------------------------------------------------------------------

--- a/app/routes/pages.py
+++ b/app/routes/pages.py
@@ -45,6 +45,7 @@ async def video_page(
     video_id: int,
     run_id: int | None = None,
     qw: int | None = None,  # quality warning flag
+    from_cache: int = 0,   # 1 = results were served from a cached run
     request: Request = None,
     session: AsyncSession = Depends(get_session),
 ):
@@ -79,6 +80,7 @@ async def video_page(
             "run": run,
             "quality_warning": bool(qw),
             "initial_focus_prompt": run.focus_prompt if run else None,
+            "from_cache": bool(from_cache),
         },
     )
 
@@ -92,6 +94,7 @@ async def video_page(
 async def partial_status(
     video_id: int,
     run_id: int | None = None,
+    from_cache: int = 0,
     request: Request = None,
     session: AsyncSession = Depends(get_session),
 ):
@@ -271,6 +274,7 @@ async def partial_status(
             "has_chapters": bool(chapters),
             "is_partial": run.status == AnalysisRunStatus.partial,
             "error_message": run.error_message,
+            "from_cache": bool(from_cache),
             "processing_time_label": processing_time_label,
         },
     )

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -138,6 +138,19 @@
           </p>
         </div>
 
+        <!-- Force regenerate toggle -->
+        <div class="flex items-center justify-between">
+          <label class="flex items-center gap-2 cursor-pointer select-none group">
+            <input
+              type="checkbox"
+              x-model="forceRegenerate"
+              :disabled="loading"
+              class="rounded border-slate-300 text-brand-600 focus:ring-brand-500 focus:ring-offset-0"
+            />
+            <span class="text-xs text-slate-500 group-hover:text-slate-700 transition-colors">Force re-run (ignore cached results)</span>
+          </label>
+        </div>
+
         <!-- Submit -->
         <button
           type="submit"
@@ -200,6 +213,7 @@ function analyzeForm() {
   return {
     url: '',
     focusPrompt: '',
+    forceRegenerate: false,
     loading: false,
     clientError: '',
     serverError: '',
@@ -274,6 +288,7 @@ function analyzeForm() {
           body: JSON.stringify({
             url: this.normalizedUrl,
             focus_prompt: this.focusPrompt.trim() || null,
+            force_regenerate: this.forceRegenerate,
           }),
         });
 
@@ -293,6 +308,7 @@ function analyzeForm() {
 
         let redirect = `/video/${data.video_id}?run_id=${data.run_id}`;
         if (data.quality_warning) redirect += '&qw=1';
+        if (data.cached) redirect += '&from_cache=1';
         window.location.href = redirect;
         return;
       } catch (err) {

--- a/app/templates/partials/results.html
+++ b/app/templates/partials/results.html
@@ -1,5 +1,14 @@
 {% set total_duration = video.duration_sec if video and video.duration_sec else (chapters[-1].end_time_sec if chapters else 0) %}
 
+{% if from_cache %}
+<div class="mb-4 flex items-center gap-1.5 text-xs text-slate-400">
+  <svg class="w-3.5 h-3.5 shrink-0 text-brand-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+  </svg>
+  <span>Loaded from previous analysis &mdash; no LLM call needed</span>
+</div>
+{% endif %}
+
 {% if is_partial and error_message %}
 <!-- Partial result notice -->
 <div class="mb-6 flex items-start gap-3 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3.5 text-sm">

--- a/app/templates/video.html
+++ b/app/templates/video.html
@@ -113,6 +113,16 @@
           aria-label="Focus prompt for regeneration"
         ></textarea>
 
+        <label class="flex items-center gap-2 cursor-pointer select-none" :class="{'opacity-50 cursor-not-allowed': regenerating}">
+          <input
+            type="checkbox"
+            x-model="forceRegenerate"
+            :disabled="regenerating"
+            class="rounded border-slate-300 text-brand-600 focus:ring-brand-500 focus:ring-offset-0"
+          />
+          <span class="text-xs text-slate-500">Force re-run (ignore cached results)</span>
+        </label>
+
         <button
           type="submit"
           :disabled="regenerating"
@@ -188,7 +198,7 @@
     <div
       id="content-area"
       class="px-5 sm:px-8 py-6"
-      hx-get="/partials/video/{{ video.id }}/status{% if run %}?run_id={{ run.id }}{% endif %}"
+      hx-get="/partials/video/{{ video.id }}/status{% if run %}?run_id={{ run.id }}{% if from_cache %}&from_cache=1{% endif %}{% endif %}"
       hx-trigger="load, every 3s [!window.__vsProcessingComplete]"
       hx-swap="innerHTML"
     >
@@ -209,6 +219,7 @@ function videoPage(videoId, youtubeId, runId) {
     youtubeId,
     runId,
     focusPrompt: '',
+    forceRegenerate: false,
     regenerating: false,
     regenStatus: '',
     regenMessage: '',
@@ -227,14 +238,17 @@ function videoPage(videoId, youtubeId, runId) {
       this._savedFocusPrompt = this.focusPrompt;
       this.regenerating = true;
       this.regenStatus = 'processing';
-      this.regenMessage = 'Starting regeneration…';
+      this.regenMessage = this.forceRegenerate ? 'Starting fresh regeneration…' : 'Checking for cached results…';
       window.__vsProcessingComplete = false;
 
       try {
         const resp = await fetch(`/api/video/${this.videoId}/regenerate`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ focus_prompt: this.focusPrompt.trim() || null }),
+          body: JSON.stringify({
+            focus_prompt: this.focusPrompt.trim() || null,
+            force_regenerate: this.forceRegenerate,
+          }),
         });
 
         if (!resp.ok) {
@@ -248,6 +262,26 @@ function videoPage(videoId, youtubeId, runId) {
 
         const data = await resp.json();
         this.runId = data.run_id;
+
+        if (data.cached) {
+          // Cache hit: results are already available — load them immediately
+          this.regenStatus  = 'done';
+          this.regenMessage = 'Loaded from previous analysis — no LLM call needed.';
+          window.vsShowToast('Loaded from cache', 'info');
+          const contentArea = document.getElementById('content-area');
+          if (contentArea) {
+            contentArea.setAttribute(
+              'hx-get',
+              `/partials/video/${this.videoId}/status?run_id=${this.runId}&from_cache=1`
+            );
+            window.__vsProcessingComplete = false;
+            htmx.process(contentArea);
+            htmx.trigger(contentArea, 'load');
+          }
+          setTimeout(() => { this.regenStatus = ''; }, 5000);
+          return;
+        }
+
         this.regenStatus  = 'processing';
         this.regenMessage = 'Reusing cached transcript — regenerating…';
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds DB-backed caching to return previously completed `AnalysisRun`s, which changes request/response behavior and could surface stale or mismatched results if the cache keying is incorrect. UI and API now branch on a new `cached`/`from_cache` flow that needs validation across analyze/regenerate paths.
> 
> **Overview**
> **Adds server-side result caching for analyses.** `POST /api/analyze` and `POST /api/video/{id}/regenerate` now look up the most recent *completed* `AnalysisRun` for the same video + focus prompt and return it immediately (no background pipeline) unless `force_regenerate` is set.
> 
> **Extends API/UI to control and surface caching.** Request schemas add `force_regenerate`, responses include a `cached` flag, and the UI adds a “Force re-run” toggle plus a “loaded from cache” indicator (propagated via `from_cache` through page/partial routes and results rendering).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ff8530f4e72122b8112f77f266a916734774caa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->