### PR TITLE
Greg/UI fold chapters into Detailed Outline

### DIFF
--- a/.cursor/plans/merge-detailed-chapters-ui_5e3b94cc.plan.md
+++ b/.cursor/plans/merge-detailed-chapters-ui_5e3b94cc.plan.md
@@ -1,0 +1,115 @@
+---
+name: merge-detailed-chapters-ui
+overview: Redesign the read screen so the Detailed Outline tab becomes a single structured surface that includes chapter-level controls, timeline, cards, and expandable transcripts while preserving existing behaviors and clean visual hierarchy.
+todos:
+  - id: analyze-ui-contract
+    content: Map current selectors/components that chapters behavior depends on
+    status: completed
+  - id: design-composite-detailed-tab
+    content: Define the merged Detailed Outline structure with chapter separators and chapter explorer
+    status: completed
+  - id: plan-template-and-context-updates
+    content: Specify route context and template changes to render grouped outline + existing chapter UI
+    status: completed
+  - id: plan-behavior-regression-checks
+    content: Define interaction and fallback tests to ensure no feature loss
+    status: completed
+isProject: false
+---
+
+# Merge Chapters Into Detailed Outline
+
+## Current State Analysis
+
+- The summary depth selector and Detailed Outline content are rendered in `[app/templates/partials/results.html](app/templates/partials/results.html)` under `activeTab === 'detailed'`.
+- Chapter timeline + chapter cards are currently a separate section (`#chapters-section`) in the same template, using reusable cards from `[app/templates/partials/chapter_card.html](app/templates/partials/chapter_card.html)`.
+- Playback-linked behaviors (active chapter highlight, timeline segment activation, keyboard `j/k`, auto-scroll) depend on global selectors in `[static/js/player.js](static/js/player.js)` and `[static/js/app.js](static/js/app.js)`:
+  - `.chapter-card`
+  - `.vs-timeline-segment`
+  - `#chapter-{chapter_id}`
+
+## Optimal UI Redesign (Information Architecture)
+
+- Keep existing three summary depth tabs/cards (Quick Take, Executive, Detailed Outline).
+- Make `Detailed Outline` a **composite tab** with two stacked layers:
+  1. **Outline stream with chapter separators** (new): detailed points grouped by chapter boundaries.
+  2. **Chapter Explorer** (existing chapters UI migrated here): mini timeline + chapter cards + key points + expandable transcript.
+- Remove the standalone Chapters block from below summaries to avoid duplication.
+
+## Proposed Layout Inside Detailed Outline
+
+- Top: compact “Outline by Chapter” heading with chapter count.
+- For each chapter group:
+  - Chapter separator row: chapter index, title, timestamp chip, duration.
+  - Nested ordered list of detailed points mapped to that chapter time window/order.
+- Divider.
+- Existing chapter timeline bar (unchanged interaction).
+- Existing chapter card list (same component and collapse/expand transcript behavior).
+
+```mermaid
+flowchart TD
+  detailedTab[DetailedOutlineTab] --> outlineLayer[OutlineByChapterLayer]
+  detailedTab --> chapterExplorer[ChapterExplorerLayer]
+  chapterExplorer --> timelineBar[TimelineSegments]
+  chapterExplorer --> chapterCards[ChapterCards]
+  chapterCards --> transcriptCollapse[ExpandableTranscript]
+  timelineBar --> seekAction[seekVideo]
+  chapterCards --> seekAction
+```
+
+
+
+## Behavior Preservation Requirements
+
+- Keep all chapter interactions exactly as-is:
+  - click timestamp -> seek
+  - click/keyboard timeline segment -> seek + scroll to chapter card
+  - player time polling -> active chapter + active segment highlighting
+  - `j/k` keyboard navigation
+  - transcript expand/collapse per chapter
+- Keep copy button semantics for active summary tab; when active tab is detailed, copy should include both outline text and chapter titles (or remain outline-only if preferred by product decision).
+
+## Data/Rendering Strategy
+
+- Reuse existing `chapters` array and `summaries.detailed.content_json` already prepared in `[app/routes/pages.py](app/routes/pages.py)`.
+- Add server-side derived structure for template rendering in `partial_status`:
+  - `detailed_outline_groups`: list of `{ chapter, points[] }`.
+- Grouping heuristic (deterministic, no schema change required):
+  - If points count equals chapter count: 1:1.
+  - Else distribute by nearest proportional index across chapter count.
+  - Fallback: put unmatched points into an “Additional points” group.
+- This avoids immediate LLM/schema refactor and gives stable rendering now.
+
+## File-Level Implementation Plan
+
+1. Update `[app/routes/pages.py](app/routes/pages.py)`
+  - Build and pass `detailed_outline_groups` into `partials/results.html` context.
+2. Update `[app/templates/partials/results.html](app/templates/partials/results.html)`
+  - Replace current flat detailed `<ol>` with grouped/chapter-separated outline.
+  - Move `#chapters-section` markup into `activeTab === 'detailed'` pane below grouped outline.
+  - Keep empty/partial-state fallbacks clean (outline-only, chapters-only, both missing).
+3. Keep `[app/templates/partials/chapter_card.html](app/templates/partials/chapter_card.html)` unchanged
+  - Preserve IDs/classes and Alpine `expanded` behavior.
+4. Minimal style additions in `[static/css/app.css](static/css/app.css)`
+  - New styles only for chapter separators in the outline layer.
+  - No visual churn to existing chapter card/timeline styling.
+5. Validate JS compatibility in `[static/js/player.js](static/js/player.js)` and `[static/js/app.js](static/js/app.js)`
+  - Ensure selectors still resolve when chapters are inside hidden/shown tab content.
+  - If needed, trigger a one-time `updateActiveChapter()` when switching to detailed tab.
+
+## UX Safeguards
+
+- Preserve clean look by using progressive disclosure:
+  - outline first (scan), chapter cards second (drill-down).
+- Keep spacing rhythm consistent with existing section spacing/tokens.
+- Ensure mobile readability by reducing separator density and keeping chips compact.
+- Maintain current loading/partial-result messaging.
+
+## Test Plan
+
+- Full result set: all tabs render, detailed shows grouped outline + chapter explorer.
+- Summaries-only partial: detailed shows outline groups with graceful missing chapter explorer notice.
+- Chapters-only partial: detailed shows chapter explorer and “outline unavailable” hint.
+- Playback interactions still work (`j/k`, timeline click, active highlight, transcript toggle).
+- No duplicate chapter section appears below summaries.
+

--- a/.cursor/plans/true-merge-detailed-chapters_c7856044.plan.md
+++ b/.cursor/plans/true-merge-detailed-chapters_c7856044.plan.md
@@ -1,0 +1,139 @@
+---
+name: true-merge-detailed-chapters
+overview: "Replace the current two-section \"Detailed Outline\" tab (outline-then-chapters) with a single unified list where each chapter is one collapsible unit containing ALL information: outline bullets, chapter summary, key points, and transcript."
+todos:
+  - id: rewrite-detailed-tab
+    content: Rewrite the detailed tab pane in results.html with unified chapter sections (remove PART 1 + PART 2, replace with single merged list)
+    status: completed
+  - id: fix-scroll-bounce
+    content: "Fix player.js scroll-bounce bug: track lastActiveCard/lastActiveBullet, only scroll on transition, suppress card scroll when bullet is active"
+    status: completed
+  - id: add-chapter-summary-css
+    content: Add minimal CSS for chapter summary text inside the unified expandable section
+    status: completed
+  - id: verify-all-interactions
+    content: Verify playback tracking, j/k nav, timeline clicks, expand/collapse, transcript toggle, and all fallback states
+    status: completed
+isProject: false
+---
+
+# True Merge: Detailed Outline + Chapters
+
+## Problem
+
+The current Detailed Outline tab has two stacked sections -- outline points grouped by chapter separators, then a complete copy of the Chapters section below a divider. This is not a merge; it's duplication. Chapter summaries, key points, and transcript only appear in the bottom section. There is also a scroll-bounce bug where chapter cards and bullet points compete for `scrollIntoView` every tick.
+
+## Target Design
+
+A single unified list where each chapter is one collapsible unit:
+
+```
+[Timeline bar]
+[Expand All / Collapse All]
+
+Chapter 1  [>0:00]  Introduction                    2m 30s   v
+  ~0:00  First detailed outline point
+  ~0:30  Second detailed outline point
+  ~1:00  Third detailed outline point
+  > Summary: "This chapter introduces..."
+  > Key points:
+    - Concise point A
+    - Concise point B
+  > View transcript (42 lines)
+
+Chapter 2  [>2:30]  Main Topic                      4m 15s   v
+  ...
+```
+
+**Always visible** (collapsed state): chapter header row with number, seekable timestamp, title, duration, chevron.
+
+**Expandable per-chapter** (toggled by click or Expand All):
+
+- Detailed outline bullet points (with `~timestamp` chips and playback tracking)
+- Chapter summary paragraph
+- Key points with checkmark icons
+- "View transcript" toggle with expandable transcript
+
+## Architecture
+
+```mermaid
+flowchart TD
+  detailedTab["Detailed Outline Tab"] --> timeline[TimelineBar]
+  detailedTab --> controls["Expand All / Collapse All"]
+  detailedTab --> chapterList["Unified Chapter List"]
+  chapterList --> ch1["Chapter Section N"]
+  ch1 --> header["Header: num + timestamp + title + duration + chevron"]
+  ch1 --> expandable["Expandable Body"]
+  expandable --> outlinePts["Outline Bullets with timestamps"]
+  expandable --> summary["Chapter Summary"]
+  expandable --> keyPts["Key Points"]
+  expandable --> transcript["Collapsible Transcript"]
+```
+
+
+
+## Files to Change
+
+### 1. `[app/templates/partials/results.html](app/templates/partials/results.html)`
+
+The detailed tab pane (lines 171-317) gets completely rewritten:
+
+- **Remove** PART 1 (separate grouped outline) AND PART 2 (separate chapter explorer)
+- **Replace** with a single unified section:
+  - Timeline bar (moved to top, before the list)
+  - Expand All / Collapse All header row
+  - Single `#chapter-list` with unified chapter sections
+- Each chapter section is a single `<div class="chapter-card ...">` to preserve all `.chapter-card` CSS selectors for `player.js`
+- Inside each chapter section's expandable body:
+  1. Outline bullets `<ol>` with `.outline-point` items (existing markup preserved for playback tracking)
+  2. Chapter summary `<p>` (from `group.chapter.summary`)
+  3. Key points `<ul>` (from `group.chapter.key_points`)
+  4. Transcript toggle (from `group.chapter.transcript_segment`)
+- The Alpine `x-data` on each unified section uses `{ localExpanded: false, transcriptOpen: false }` exactly like current `chapter_card.html`, with parent `allExpanded` binding
+- Keep `data-start`, `data-end`, `id="chapter-{chapter_id}"` on each section for player.js compatibility
+
+The separate `chapter_card.html` include is no longer used within the detailed tab. The fallback (chapters-only, no summaries) at lines 327-387 can still use `chapter_card.html` as-is.
+
+### 2. `[static/js/player.js](static/js/player.js)`
+
+Fix the scroll-bounce bug with transition-based scrolling:
+
+- Track `lastActiveCard` and `lastActiveBullet` across ticks
+- Only call `scrollIntoView` when an element **transitions** from inactive to active (wasn't active last tick)
+- When a bullet is active, **suppress** chapter-card auto-scroll (the bullet is the finer-grained target within the same visible area)
+- Reset trackers when playback stops
+
+### 3. `[app/templates/partials/chapter_card.html](app/templates/partials/chapter_card.html)`
+
+No changes needed. It continues to be used by the fallback standalone chapters section (no-summaries case).
+
+### 4. `[app/routes/pages.py](app/routes/pages.py)`
+
+No changes needed. The `detailed_outline_groups` already contains `{ chapter: {..., summary, key_points, transcript_segment, ...}, points: [{text, timestamp_sec, end_timestamp_sec, ...}] }` -- all the data needed for the unified view is already being passed.
+
+### 5. `[static/css/app.css](static/css/app.css)`
+
+Minor additions:
+
+- `.vs-chapter-summary` for the chapter summary paragraph inside the expandable area (subtle styling to distinguish from outline bullets)
+- Reuse existing `.chapter-card`, `.chapter-card-header`, `.chapter-card-chevron`, `.is-active-chapter` classes unchanged so player.js and existing styles work
+
+### 6. `[static/js/app.js](static/js/app.js)`
+
+No changes needed -- `navigateChapter`, `ensureDetailedTabActive`, and timeline segment handlers all use `.chapter-card` selectors which will continue to work.
+
+## Key Design Decisions
+
+- The unified chapter section reuses the `.chapter-card` class and `id="chapter-{id}"` / `data-start` / `data-end` attributes. This means ALL existing player.js highlighting, app.js keyboard navigation, and CSS active states work without selector changes.
+- Outline bullets keep their `.outline-point` class and `data-start`/`data-end` attributes for bullet-level playback tracking.
+- The chapter header is clickable to expand/collapse (like current chapter cards), with the timestamp chip clickable to seek (with `stopPropagation`).
+- "Now Playing" badge stays on the chapter header row.
+- Expand All / Collapse All goes at the top of the detailed tab, next to the timeline.
+
+## Fallback / Partial States
+
+- **Both available**: unified merged view as described
+- **Outline only, no chapters**: flat numbered list (no chapter structure) -- existing ungrouped fallback, no expand/collapse needed
+- **Chapters only, no summaries**: standalone chapters section using `chapter_card.html` (the `{% if not has_summaries %}` fallback block at end of results.html)
+- **Neither**: empty state message
+

--- a/.cursor/plans/vidsense_ux_improvements_29cb5313.plan.md
+++ b/.cursor/plans/vidsense_ux_improvements_29cb5313.plan.md
@@ -1,0 +1,357 @@
+---
+name: VidSense UX Improvements
+overview: "Four improvements to VidSense: progressive result streaming (chapters appear as generated), YouTube metadata and link display, fixed-height summary section to prevent chapter shifting, and processing time display."
+todos:
+  - id: db-schema
+    content: Add YouTube metadata columns to Video model + migration helper for existing SQLite DBs
+    status: completed
+  - id: youtube-metadata
+    content: Populate new metadata fields in youtube.py during ingestion
+    status: completed
+  - id: progressive-pipeline
+    content: Refactor LangGraph nodes to persist summaries/chapters immediately instead of batching in persist_results
+    status: completed
+  - id: progressive-polling
+    content: Enhance partial_status endpoint to return intermediate results during processing
+    status: completed
+  - id: progressive-template
+    content: Modify processing.html to show available results + skeletons for pending components
+    status: completed
+  - id: layout-fix
+    content: "Fixed-height summary section with CSS resize: vertical; add YouTube link + copy button to right panel info bar"
+    status: completed
+  - id: yt-metadata-ui
+    content: Add collapsible Video Details section below chapters in left panel
+    status: completed
+  - id: timing-display
+    content: Show total processing time in results header after completion
+    status: completed
+  - id: collapsible-chapters
+    content: Make chapter cards collapsible with Expand All / Collapse All controls; collapsed shows only header + summary
+    status: completed
+isProject: false
+---
+
+# VidSense UX Improvements Plan
+
+## Current Architecture
+
+The processing pipeline (LangGraph) runs `gen_summaries` and `extract_chapters` in parallel, then persists everything at once in `persist_results`. The frontend polls via HTMX every 3s and gets either a processing skeleton or the full results. No intermediate results are shown.
+
+```mermaid
+flowchart LR
+    A[validate_input] --> B[gen_summaries]
+    A --> C[extract_chapters]
+    B --> D[persist_results]
+    C --> D
+    D --> E[END]
+```
+
+
+
+Current layout (kept, with improvements):
+
+```
+LEFT (scrollable)                    RIGHT (38%, sticky)
+- Summaries (3 tabs, fixed-height)   - YouTube Player
+- Chapters (timeline + cards)        - Title + duration + YT link
+- Video Details (collapsible)        - Regenerate form
+                                     - Keyboard shortcuts
+```
+
+---
+
+## Change 1: Progressive Results (Chapter-by-Chapter)
+
+### Problem
+
+Long videos can take 3-5 minutes. The user sees only a skeleton loader until the entire pipeline finishes.
+
+### Approach: Persist-as-you-go + enhanced polling
+
+**Pipeline changes** in `[app/services/llm/nodes.py](app/services/llm/nodes.py)`:
+
+- `gen_summaries_node`: after the LLM call succeeds, persist the 3 summaries to DB immediately (move persistence logic from `persist_results_node`)
+- `extract_chapters_node`: for chunked extraction (long videos), persist each chunk's chapters to DB as soon as the chunk completes, rather than accumulating all and persisting at the end
+- Rename `persist_results_node` to `finalize_run_node`: it only sets `run.status` and `run.completed_at` based on what was persisted. No more persistence logic here.
+- Update `_set_step` to write more granular steps: `"generating_summaries"`, `"extracting_chapters"`, `"chapters_chunk_2_of_5"`, etc.
+
+**Graph changes** in `[app/services/llm/graph.py](app/services/llm/graph.py)`: topology stays the same (parallel fan-out, fan-in to finalize). The nodes themselves now handle persistence.
+
+**Polling endpoint changes** in `[app/routes/pages.py](app/routes/pages.py)`:
+
+- When `run.status` is `processing`, query DB for any already-persisted summaries/chapters for this run
+- If intermediate results exist, render a **progressive** version of the results (real data + skeleton placeholders for pending sections)
+- If no results yet, render the existing processing skeleton
+
+**Template changes** in `[app/templates/partials/processing.html](app/templates/partials/processing.html)`:
+
+- When intermediate summaries or chapters are available, render them inline (reusing the same markup from `results.html`) alongside skeletons for the not-yet-ready sections
+- Keep the stepper bar + elapsed timer at top
+- Add a subtle "Still generating..." pulse indicator on skeleton sections
+
+**Timing display**:
+
+- During processing: elapsed timer already exists via `processingTimer()` Alpine component
+- After completion: compute `completed_at - created_at` and display as "Processed in Xm Ys" in the results header
+- The `AnalysisRun` model already has `created_at` and `completed_at` -- no schema change needed for timing
+
+---
+
+## Change 2: YouTube Metadata Display
+
+### DB Schema Changes in `[app/models/db.py](app/models/db.py)`
+
+Add columns to the `Video` model:
+
+```python
+channel_name: Mapped[str | None] = mapped_column(String(256))
+channel_url: Mapped[str | None] = mapped_column(String(512))
+description: Mapped[str | None] = mapped_column(Text)
+upload_date: Mapped[str | None] = mapped_column(String(20))
+view_count: Mapped[int | None] = mapped_column(Integer)
+like_count: Mapped[int | None] = mapped_column(Integer)
+```
+
+### Ingestion Changes in `[app/services/youtube.py](app/services/youtube.py)`
+
+In `ingest_video()`, populate the new fields from the yt-dlp metadata dict:
+
+```python
+video = Video(
+    # ... existing fields ...
+    channel_name=metadata.get("uploader") or metadata.get("channel"),
+    channel_url=metadata.get("channel_url") or metadata.get("uploader_url"),
+    description=metadata.get("description"),
+    upload_date=metadata.get("upload_date"),  # "YYYYMMDD" format from yt-dlp
+    view_count=metadata.get("view_count"),
+    like_count=metadata.get("like_count"),
+)
+```
+
+### DB Migration
+
+Since this uses SQLite with `Base.metadata.create_all` at startup (which only creates new tables, not new columns on existing tables), add a lightweight startup migration helper in `[app/database.py](app/database.py)` that runs `ALTER TABLE videos ADD COLUMN ...` for each missing column, wrapped in try/except to handle the "column already exists" case gracefully. No Alembic dependency needed.
+
+### UI Display
+
+Add a collapsible "Video Details" section in the left panel (below chapters) showing:
+
+- Channel name (linked to channel URL)
+- Upload date (formatted nicely, e.g. "Mar 15, 2026")
+- View count + like count (formatted with commas)
+- Description (truncated to ~3 lines with "Show more" expand using Alpine `x-show`)
+- URLs in description auto-linked as clickable references
+
+This will be a new partial `[app/templates/partials/video_metadata.html](app/templates/partials/video_metadata.html)` included in `results.html` after the chapters section.
+
+---
+
+## Change 3: YouTube Link (View + Copy)
+
+### In the right panel's video info bar (`[app/templates/video.html](app/templates/video.html)` lines 58-73)
+
+Enhance the current info bar to include a "YouTube" link (opens in new tab) and a copy-to-clipboard button:
+
+```html
+<div class="px-4 pt-3 pb-2.5 border-b border-slate-100 shrink-0">
+  <h1 class="font-semibold text-slate-900 text-sm leading-snug line-clamp-2">
+    {{ video.title or 'Untitled Video' }}
+  </h1>
+  <div class="flex items-center gap-2 mt-1.5 text-xs text-slate-400 flex-wrap">
+    <span>{{ duration }}</span>
+    <span class="text-slate-300">&middot;</span>
+    <a href="{{ video.url }}" target="_blank" rel="noopener"
+       class="text-brand-600 hover:text-brand-700 hover:underline inline-flex items-center gap-1">
+      <svg class="w-3 h-3"><!-- external-link icon --></svg>
+      YouTube
+    </a>
+    <button @click="window.vsCopyToClipboard('{{ video.url }}', 'YouTube link')"
+            title="Copy YouTube link"
+            class="text-slate-400 hover:text-brand-600 transition-colors">
+      <svg class="w-3.5 h-3.5"><!-- clipboard icon --></svg>
+    </button>
+  </div>
+</div>
+```
+
+The `vsCopyToClipboard` helper already exists in `[static/js/app.js](static/js/app.js)`.
+
+---
+
+## Change 4: Fixed-Height Summary Section (Prevent Chapter Shifting)
+
+### Problem
+
+Currently, the summary content (Quick Take / Executive / Detailed Outline) sits above chapters in the left panel. Switching tabs changes the content height, causing chapters below to shift up/down.
+
+### Solution
+
+Wrap the summary content area in a fixed `max-height` container with `overflow-y: auto` and `resize: vertical`.
+
+In `[app/templates/partials/results.html](app/templates/partials/results.html)`, around lines 112-179 (the summary content panes):
+
+```html
+<div class="summary-content-container overflow-y-auto resize-y"
+     style="max-height: 28rem; min-height: 8rem;">
+  <!-- Quick Take pane -->
+  <div x-show="activeTab === 'thesis'" ...>...</div>
+  <!-- Executive pane -->
+  <div x-show="activeTab === 'executive'" ...>...</div>
+  <!-- Detailed Outline pane -->
+  <div x-show="activeTab === 'detailed'" ...>...</div>
+</div>
+```
+
+- `max-height: 28rem` (~448px) provides generous space for the Detailed Outline (typically 10-20 bullet points) while keeping chapters visible without scrolling the entire page
+- `resize: vertical` adds a native browser drag handle at the bottom-right corner of the summary box, letting the user manually adjust the height
+- `min-height: 8rem` prevents collapsing to nothing
+- `overflow-y: auto` shows a scrollbar only when content exceeds the max-height
+
+Add supporting CSS in `[static/css/app.css](static/css/app.css)`:
+
+```css
+.summary-content-container {
+  border-bottom: 1px solid theme('colors.slate.100');
+  padding-bottom: 1rem;
+  margin-bottom: 1.5rem;
+}
+```
+
+### Why this works
+
+- Chapters always start at the same vertical position regardless of which summary tab is active
+- The Detailed Outline (longest content) fits comfortably in 28rem for typical videos
+- User can drag to resize if they want more/less space
+- No layout restructuring needed -- same left/right panel arrangement, same single HTMX polling target
+
+---
+
+## Change 5: Collapsible Chapter Cards with Expand/Collapse All
+
+### Current Behavior
+
+Each chapter card in `[app/templates/partials/chapter_card.html](app/templates/partials/chapter_card.html)` always shows:
+
+- Header row: number, timestamp button, title, "Now Playing" badge, duration
+- Summary paragraph (1-2 sentences)
+- Key points bullet list (always visible)
+- Transcript segment (expandable, collapsed by default)
+
+For videos with many chapters, the page is very long and hard to scan.
+
+### New Behavior
+
+**Collapsed state** (default): compact row showing only:
+
+- Chapter number + timestamp button + title + duration
+- One-line summary text (truncated if needed)
+
+**Expanded state**: everything currently shown (summary, key points, transcript toggle).
+
+**Expand All / Collapse All** controls at the chapter section header.
+
+### Implementation
+
+**Parent-level Alpine state** in `[app/templates/partials/results.html](app/templates/partials/results.html)`, on the `#chapters-section` div:
+
+```html
+<div id="chapters-section" x-data="{ allExpanded: false }">
+  <div class="flex items-center justify-between mb-3">
+    <h2 class="text-xl font-bold text-slate-900">
+      Chapters <span class="ml-2 text-sm font-normal text-slate-400">({{ chapters|length }})</span>
+    </h2>
+    <button @click="allExpanded = !allExpanded"
+            class="text-xs text-slate-400 hover:text-brand-600 transition-colors">
+      <span x-text="allExpanded ? 'Collapse all' : 'Expand all'"></span>
+    </button>
+  </div>
+  <!-- timeline + chapter cards -->
+</div>
+```
+
+**Per-card state** in `[app/templates/partials/chapter_card.html](app/templates/partials/chapter_card.html)`:
+
+Change the existing `x-data="{ expanded: false }"` to react to the parent's `allExpanded`:
+
+```html
+<div class="chapter-card ..."
+     x-data="{ localExpanded: false, expanded: false }"
+     x-effect="expanded = allExpanded || localExpanded"
+     ...>
+```
+
+- `allExpanded` comes from the parent scope (Alpine scoping propagates down)
+- `localExpanded` tracks per-card toggle (clicking a card toggles just that card)
+- `expanded` is the computed state: true if either the global toggle or the local toggle is on
+
+**Card header becomes clickable** to toggle `localExpanded`:
+
+```html
+<div class="flex items-start gap-3 p-4 cursor-pointer select-none"
+     @click="localExpanded = !localExpanded">
+  <!-- number, timestamp, title, duration (always visible) -->
+  <!-- chevron icon that rotates when expanded -->
+</div>
+```
+
+**Collapsible body** wraps key points + transcript:
+
+```html
+<div x-show="expanded" x-collapse>
+  <!-- summary paragraph (full, not truncated) -->
+  <!-- key points list -->
+  <!-- transcript toggle -->
+</div>
+```
+
+The **summary line** in collapsed state shows a truncated one-liner via `line-clamp-1`, and in expanded state shows the full text. This can be done with:
+
+```html
+<p class="text-slate-500 text-xs mt-1 leading-relaxed"
+   :class="expanded ? '' : 'line-clamp-1'">
+  {{ chapter.summary }}
+</p>
+```
+
+The summary stays visible in both states (just truncated vs full), while key points and transcript are hidden when collapsed.
+
+### Alpine `x-collapse` Plugin
+
+For smooth height animation, use Alpine's `x-collapse` plugin (already available via CDN). This animates the height transition instead of the abrupt `x-show` toggle. If not already included, add to `[app/templates/base.html](app/templates/base.html)`:
+
+```html
+<script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/collapse@3.x.x/dist/cdn.min.js"></script>
+```
+
+This must be loaded **before** the main Alpine script.
+
+### Files Changed
+
+- `[app/templates/partials/results.html](app/templates/partials/results.html)`: Add `x-data` with `allExpanded` to chapters section; add Expand/Collapse All button
+- `[app/templates/partials/chapter_card.html](app/templates/partials/chapter_card.html)`: Restructure to make header clickable, wrap key points + transcript in collapsible body, add chevron indicator
+- `[app/templates/base.html](app/templates/base.html)`: Add Alpine Collapse plugin CDN (if not already present)
+- `[static/css/app.css](static/css/app.css)`: Transition styles for collapse animation, cursor pointer on card header
+
+---
+
+## File Change Summary
+
+
+| File                                              | Changes                                                                                                   |
+| ------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `app/models/db.py`                                | Add 6 metadata columns to Video model                                                                     |
+| `app/database.py`                                 | Add startup migration helper for new Video columns                                                        |
+| `app/services/youtube.py`                         | Populate new metadata fields from yt-dlp                                                                  |
+| `app/services/llm/nodes.py`                       | Persist summaries/chapters in their own nodes; rename persist_results to finalize_run                     |
+| `app/services/llm/graph.py`                       | Update node name reference                                                                                |
+| `app/routes/pages.py`                             | Return intermediate results during processing; pass timing data to results template                       |
+| `app/templates/video.html`                        | Add YouTube link + copy button to info bar                                                                |
+| `app/templates/base.html`                         | Add Alpine Collapse plugin CDN                                                                            |
+| `app/templates/partials/results.html`             | Fixed-height summary container; processing time; video metadata include; Expand/Collapse All for chapters |
+| `app/templates/partials/chapter_card.html`        | Collapsible cards: clickable header, hidden key points + transcript when collapsed, chevron indicator     |
+| `app/templates/partials/processing.html`          | Support progressive state (show available results + skeletons for pending sections)                       |
+| `static/css/app.css`                              | Styles for summary container, resize handle, metadata section, collapse animations                        |
+| New: `app/templates/partials/video_metadata.html` | Collapsible YouTube metadata display                                                                      |
+
+

--- a/app/routes/pages.py
+++ b/app/routes/pages.py
@@ -285,8 +285,12 @@ async def partial_status(
                     # boundary (which is the next chapter's start).
                     ts = chapter["start_time_sec"] + round(j * ch_dur / max(n_ch, 1))
                     ts = max(chapter["start_time_sec"], min(ts, chapter["end_time_sec"]))
-                    end_ts = chapter["start_time_sec"] + round((j + 1) * ch_dur / max(n_ch, 1))
-                    end_ts = max(ts + 1, min(end_ts, chapter["end_time_sec"]))
+                    raw_end = chapter["start_time_sec"] + round((j + 1) * ch_dur / max(n_ch, 1))
+                    raw_end = min(raw_end, chapter["end_time_sec"])
+                    # Clamp end_ts to chapter end *after* max(ts+1, ...). Doing min(end, chapter_end)
+                    # before max(ts+1, ...) makes end_ts = chapter_end+1 when ts was clamped to
+                    # chapter_end (player.js uses start <= t < end; overflow highlights next chapter).
+                    end_ts = min(chapter["end_time_sec"], max(ts + 1, raw_end))
                     enriched_pts.append(
                         {
                             "text": text,

--- a/app/routes/pages.py
+++ b/app/routes/pages.py
@@ -251,6 +251,55 @@ async def partial_status(
             "content_json": content_json,
         }
 
+    # Build detailed_outline_groups for the composite Detailed Outline + Chapter Explorer tab.
+    # Each group maps one chapter to a proportional slice of the detailed outline points.
+    detailed_points: list[str] = []
+    detailed_entry = enriched_summaries.get("detailed", {})
+    if detailed_entry.get("content_json"):
+        detailed_points = detailed_entry["content_json"]
+    elif detailed_entry.get("content_text"):
+        detailed_points = [
+            line.lstrip("•-*0123456789. ").strip()
+            for line in detailed_entry["content_text"].split("\n")
+            if line.strip()
+        ]
+
+    detailed_outline_groups: list[dict] = []
+    if enriched_chapters:
+        # Always create one group per chapter. Outline points are distributed
+        # proportionally; if no outline exists, the points list is empty but
+        # the chapter header/summary/key-points/transcript still render.
+        n_points = len(detailed_points)
+        n_chapters = len(enriched_chapters)
+        for i, chapter in enumerate(enriched_chapters):
+            enriched_pts: list[dict] = []
+            if detailed_points:
+                start_idx = round(i * n_points / n_chapters)
+                end_idx = round((i + 1) * n_points / n_chapters)
+                chapter_points = detailed_points[start_idx:end_idx]
+                n_ch = len(chapter_points)
+                ch_dur = chapter["end_time_sec"] - chapter["start_time_sec"]
+                for j, text in enumerate(chapter_points):
+                    # Distribute timestamps proportionally within the chapter.
+                    # Use j/n_ch so the last point doesn't land on the chapter
+                    # boundary (which is the next chapter's start).
+                    ts = chapter["start_time_sec"] + round(j * ch_dur / max(n_ch, 1))
+                    ts = max(chapter["start_time_sec"], min(ts, chapter["end_time_sec"]))
+                    end_ts = chapter["start_time_sec"] + round((j + 1) * ch_dur / max(n_ch, 1))
+                    end_ts = max(ts + 1, min(end_ts, chapter["end_time_sec"]))
+                    enriched_pts.append(
+                        {
+                            "text": text,
+                            "timestamp_sec": ts,
+                            "end_timestamp_sec": end_ts,
+                            "timestamp_display": _seconds_to_mmss(ts),
+                        }
+                    )
+            detailed_outline_groups.append({"chapter": chapter, "points": enriched_pts})
+    elif detailed_points:
+        # Outline available but no chapters — single ungrouped block (no timestamps)
+        detailed_outline_groups = [{"chapter": None, "points": detailed_points}]
+
     # Compute total processing time
     processing_time_label: str | None = None
     if run.completed_at and run.created_at:
@@ -270,6 +319,7 @@ async def partial_status(
             "video_id": video_id,
             "summaries": enriched_summaries,
             "chapters": enriched_chapters,
+            "detailed_outline_groups": detailed_outline_groups,
             "has_summaries": bool(summaries),
             "has_chapters": bool(chapters),
             "is_partial": run.status == AnalysisRunStatus.partial,

--- a/app/templates/partials/results.html
+++ b/app/templates/partials/results.html
@@ -103,7 +103,7 @@
       <p class="text-xs mt-0.5 leading-snug" :class="activeTab === 'executive' ? 'text-brand-600' : 'text-slate-400'">Full narrative context · ~1–2 min read</p>
     </button>
 
-    <!-- Detailed Outline -->
+    <!-- Detailed Outline (+ Chapters) -->
     <button
       role="tab"
       :aria-selected="activeTab === 'detailed'"
@@ -119,13 +119,16 @@
         </div>
       </div>
       <p class="text-xs font-bold" :class="activeTab === 'detailed' ? 'text-brand-700' : 'text-slate-700'">Detailed Outline</p>
-      <p class="text-xs mt-0.5 leading-snug" :class="activeTab === 'detailed' ? 'text-brand-600' : 'text-slate-400'">Every point covered · scannable list</p>
+      <p class="text-xs mt-0.5 leading-snug" :class="activeTab === 'detailed' ? 'text-brand-600' : 'text-slate-400'">
+        {%- if has_chapters %}Full outline &amp; {{ chapters | length }} chapters · deep dive
+        {%- else %}Every point covered · scannable list{% endif -%}
+      </p>
     </button>
 
   </div>
 
-  <!-- Fixed-height scrollable summary content — prevents chapters below from shifting -->
-  <div class="summary-content-container overflow-y-auto" style="max-height: 28rem; min-height: 8rem;">
+  <!-- Quick Take and Executive use a constrained scrollable container to prevent page jump -->
+  <div class="overflow-y-auto" :style="activeTab !== 'detailed' ? 'max-height:28rem;min-height:8rem;' : ''">
 
     <!-- Quick Take (thesis) -->
     <div x-show="activeTab === 'thesis'"
@@ -162,128 +165,331 @@
       {% endif %}
     </div>
 
-    <!-- Detailed Outline -->
+    <!-- ============================================================
+         DETAILED OUTLINE — unified chapter list (true merge)
+         ============================================================ -->
     <div x-show="activeTab === 'detailed'" x-cloak
          x-transition:enter="transition-opacity duration-150"
          x-transition:enter-start="opacity-0"
          x-transition:enter-end="opacity-100">
-      {% if summaries.detailed %}
-      <ol id="summary-text-detailed" class="space-y-2">
-        {% if summaries.detailed.content_json %}
-          {% for point in summaries.detailed.content_json %}
-          <li class="flex items-start gap-3 text-slate-700 text-sm leading-relaxed">
-            <span class="shrink-0 w-5 h-5 rounded-full bg-brand-100 text-brand-700 text-xs font-bold flex items-center justify-center mt-0.5">{{ loop.index }}</span>
-            <span>{{ point }}</span>
-          </li>
-          {% endfor %}
-        {% else %}
-          {% for line in summaries.detailed.content_text.split('\n') %}
-          {% if line.strip() %}
-          <li class="flex items-start gap-3 text-slate-700 text-sm leading-relaxed">
-            <span class="shrink-0 w-5 h-5 rounded-full bg-brand-100 text-brand-700 text-xs font-bold flex items-center justify-center mt-0.5">{{ loop.index }}</span>
-            <span>{{ line.lstrip('•-*0123456789. ') }}</span>
-          </li>
-          {% endif %}
-          {% endfor %}
+
+      {% if detailed_outline_groups and detailed_outline_groups[0].chapter %}
+      <!-- ── Unified: each chapter is one collapsible unit ── -->
+      <div x-data="{ allExpanded: false }" id="summary-text-detailed">
+
+        <!-- Mini timeline bar -->
+        {% if total_duration and total_duration > 0 %}
+        <div class="mb-4">
+          <div class="vs-timeline mb-1" role="group" aria-label="Video chapter timeline">
+            {% set tl_colors = ['#0284c7','#0369a1','#0ea5e9','#38bdf8','#7dd3fc','#2563eb','#1d4ed8','#3b82f6'] %}
+            {% for group in detailed_outline_groups %}
+            {% set ch = group.chapter %}
+            {% set pct_left  = (ch.start_time_sec / total_duration * 100) | round(2) %}
+            {% set pct_width = ((ch.end_time_sec - ch.start_time_sec) / total_duration * 100) | round(2) %}
+            {% set tl_color  = tl_colors[loop.index0 % (tl_colors | length)] %}
+            <div
+              class="vs-timeline-segment"
+              style="left:{{ pct_left }}%; width:{{ [pct_width, 1] | max }}%; background:{{ tl_color }};"
+              data-start="{{ ch.start_time_sec }}"
+              data-chapter-id="{{ ch.chapter_id }}"
+              title="Ch.{{ loop.index }}: {{ ch.title }} ({{ ch.start_display }})"
+              role="button"
+              tabindex="0"
+              aria-label="Jump to chapter {{ loop.index }}: {{ ch.title }}"
+            ></div>
+            {% endfor %}
+          </div>
+          <div class="flex justify-between text-xs text-slate-400 px-0.5">
+            <span>0:00</span>
+            {% if video and video.duration_sec %}
+            <span>{{ (video.duration_sec // 60) }}:{{ '%02d' % (video.duration_sec % 60) }}</span>
+            {% endif %}
+          </div>
+        </div>
         {% endif %}
+
+        <!-- Controls: chapter count + Expand / Collapse All -->
+        <div class="flex items-center justify-between mb-3">
+          <span class="text-xs font-semibold text-slate-500 uppercase tracking-wider">
+            {{ detailed_outline_groups | length }} chapters
+          </span>
+          <button
+            @click="allExpanded = !allExpanded"
+            class="flex items-center gap-1 text-xs text-slate-400 hover:text-brand-600 transition-colors focus:outline-none focus:ring-2 focus:ring-brand-400 rounded px-2 py-1"
+          >
+            <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path x-show="!allExpanded" stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+              <path x-show="allExpanded" x-cloak stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" />
+            </svg>
+            <span x-text="allExpanded ? 'Collapse all' : 'Expand all'"></span>
+          </button>
+        </div>
+
+        <!-- Unified chapter list -->
+        <div class="space-y-2" id="chapter-list">
+          {% for group in detailed_outline_groups %}
+          {% set chapter = group.chapter %}
+          {% set dur_sec = chapter.end_time_sec - chapter.start_time_sec %}
+          {% set dur_m   = dur_sec // 60 %}
+          {% set dur_s   = dur_sec % 60 %}
+          {% set dur_display = (dur_m ~ 'm ' ~ dur_s ~ 's') if dur_m > 0 else (dur_s ~ 's') %}
+          {% set line_count  = chapter.transcript_segment.count('\n') + 1 if chapter.transcript_segment else 0 %}
+          {% set ch_idx = loop.index %}
+
+          <div
+            class="chapter-card group border border-slate-200 rounded-xl bg-white"
+            data-start="{{ chapter.start_time_sec }}"
+            data-end="{{ chapter.end_time_sec }}"
+            id="chapter-{{ chapter.chapter_id }}"
+            x-data="{ localExpanded: false, transcriptOpen: false }"
+          >
+            <!-- Clickable header: expand/collapse + timestamp + title + badge + duration + chevron -->
+            <div
+              class="chapter-card-header flex items-start gap-3 p-4"
+              @click="localExpanded = !localExpanded"
+              role="button"
+              tabindex="0"
+              @keydown.enter.prevent="localExpanded = !localExpanded"
+              @keydown.space.prevent="localExpanded = !localExpanded"
+              :aria-expanded="allExpanded || localExpanded"
+            >
+              <span class="shrink-0 text-xs font-bold text-slate-400 w-5 text-right mt-0.5 select-none">{{ ch_idx }}</span>
+
+              <button
+                onclick="event.stopPropagation(); seekVideo({{ chapter.start_time_sec }})"
+                class="shrink-0 inline-flex items-center gap-1 font-mono text-sm font-semibold text-brand-600 hover:text-brand-800 bg-brand-50 hover:bg-brand-100 border border-brand-200 rounded-md px-2 py-1 transition-colors focus:outline-none focus:ring-2 focus:ring-brand-400 mt-0.5"
+                title="Jump to {{ chapter.start_display }}"
+                aria-label="Jump to chapter {{ ch_idx }} at {{ chapter.start_display }}"
+              >
+                <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>
+                {{ chapter.start_display }}
+              </button>
+
+              <div class="flex-1 min-w-0">
+                <div class="flex items-start justify-between gap-2">
+                  <h3 class="font-semibold text-slate-900 text-sm leading-snug">{{ chapter.title }}</h3>
+                  <span class="shrink-0 hidden is-active-chapter-badge text-xs font-semibold text-brand-600 bg-brand-50 border border-brand-200 rounded-full px-2 py-0.5 whitespace-nowrap">Now Playing</span>
+                </div>
+              </div>
+
+              <span class="shrink-0 text-xs text-slate-400 font-medium mt-1 whitespace-nowrap">{{ dur_display }}</span>
+
+              <svg
+                class="chapter-card-chevron shrink-0 w-3.5 h-3.5 text-slate-300 mt-1"
+                :class="(allExpanded || localExpanded) ? 'is-expanded' : ''"
+                fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+              </svg>
+            </div>
+
+            <!-- Expandable body -->
+            <div
+              x-show="allExpanded || localExpanded"
+              x-cloak
+              x-transition:enter="transition-opacity duration-150"
+              x-transition:enter-start="opacity-0"
+              x-transition:enter-end="opacity-100"
+            >
+
+              <!-- 1. Detailed outline bullets with seekable timestamps -->
+              {% if group.points %}
+              <div class="px-4 pb-2 pt-1 border-t border-slate-50">
+                <ol class="space-y-1 mt-1">
+                  {% for point in group.points %}
+                  <li
+                    class="outline-point flex items-start gap-2 text-slate-700 text-sm leading-relaxed rounded-md px-1.5 py-1 -mx-1.5 transition-colors duration-150"
+                    data-start="{{ point.timestamp_sec }}"
+                    data-end="{{ point.end_timestamp_sec }}"
+                  >
+                    <span class="outline-point-badge shrink-0 w-4 h-4 rounded-full bg-brand-50 text-brand-600 text-xs font-bold flex items-center justify-center mt-0.5 border border-brand-200 transition-colors duration-150">{{ loop.index }}</span>
+                    <button
+                      onclick="seekVideo({{ point.timestamp_sec }})"
+                      class="vs-outline-point-ts shrink-0 mt-0.5"
+                      title="Seek to ~{{ point.timestamp_display }}"
+                      aria-label="Seek to approximately {{ point.timestamp_display }}"
+                    >~{{ point.timestamp_display }}</button>
+                    <span class="outline-point-text">{{ point.text }}</span>
+                  </li>
+                  {% endfor %}
+                </ol>
+              </div>
+              {% endif %}
+
+              <!-- 2. Chapter summary -->
+              {% if chapter.summary %}
+              <div class="px-4 py-2.5 border-t border-slate-50">
+                <p class="vs-chapter-summary">{{ chapter.summary }}</p>
+              </div>
+              {% endif %}
+
+              <!-- 3. Key points -->
+              {% if chapter.key_points %}
+              <div class="px-4 pb-3 pt-2 border-t border-slate-50">
+                <ul class="space-y-1.5">
+                  {% for point in chapter.key_points %}
+                  <li class="flex items-start gap-2 text-xs text-slate-600 leading-relaxed">
+                    <svg class="w-3.5 h-3.5 text-brand-400 shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+                    </svg>
+                    <span>{{ point }}</span>
+                  </li>
+                  {% endfor %}
+                </ul>
+              </div>
+              {% endif %}
+
+              <!-- 4. Collapsible transcript -->
+              {% if chapter.transcript_segment %}
+              <div class="border-t border-slate-100 px-4">
+                <button
+                  @click.stop="transcriptOpen = !transcriptOpen"
+                  class="flex items-center gap-1.5 text-xs text-slate-400 hover:text-slate-600 py-2.5 transition-colors focus:outline-none w-full"
+                  :aria-expanded="transcriptOpen"
+                  aria-controls="transcript-{{ chapter.chapter_id }}"
+                >
+                  <svg
+                    class="w-3.5 h-3.5 transition-transform duration-150"
+                    :class="{ 'rotate-90': transcriptOpen }"
+                    fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"
+                  >
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+                  </svg>
+                  <span x-text="transcriptOpen ? 'Hide transcript' : 'View transcript{% if line_count > 0 %} ({{ line_count }} lines){% endif %}'"></span>
+                </button>
+                <div
+                  id="transcript-{{ chapter.chapter_id }}"
+                  x-show="transcriptOpen"
+                  x-cloak
+                  x-transition:enter="transition-opacity duration-150"
+                  x-transition:enter-start="opacity-0"
+                  x-transition:enter-end="opacity-100"
+                  class="pb-4"
+                >
+                  <p class="text-xs text-slate-500 leading-relaxed font-mono bg-slate-50 rounded-lg px-3 py-2.5 whitespace-pre-wrap">{{ chapter.transcript_segment }}</p>
+                </div>
+              </div>
+              {% endif %}
+
+            </div><!-- end expandable body -->
+          </div><!-- end chapter-card -->
+
+          {% endfor %}
+        </div><!-- end #chapter-list -->
+
+      </div><!-- end x-data allExpanded / #summary-text-detailed -->
+
+      {% elif detailed_outline_groups %}
+      <!-- Ungrouped outline (outline exists but no chapters) -->
+      <ol id="summary-text-detailed" class="space-y-2">
+        {% for point in detailed_outline_groups[0].points %}
+        <li class="flex items-start gap-3 text-slate-700 text-sm leading-relaxed">
+          <span class="shrink-0 w-5 h-5 rounded-full bg-brand-100 text-brand-700 text-xs font-bold flex items-center justify-center mt-0.5">{{ loop.index }}</span>
+          <span>{{ point }}</span>
+        </li>
+        {% endfor %}
       </ol>
+
       {% else %}
-      <p class="text-slate-400 italic text-sm">Detailed outline not available.</p>
+      <p class="text-slate-400 italic text-sm mb-4">Detailed outline not available.</p>
       {% endif %}
-    </div>
 
-  </div><!-- end summary-content-container -->
+      <!-- Chapter extraction failed (outline available but no chapters) -->
+      {% if not has_chapters and summaries.detailed %}
+      <div class="mt-6 flex items-start gap-3 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3.5 text-sm">
+        <svg class="w-4 h-4 mt-0.5 flex-shrink-0 text-amber-500" fill="currentColor" viewBox="0 0 20 20">
+          <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
+        </svg>
+        <div>
+          <p class="font-semibold text-amber-900">Chapter extraction was not completed</p>
+          <p class="text-amber-700 text-xs mt-0.5">Use the Regenerate button on the right to try again.</p>
+        </div>
+      </div>
+      {% endif %}
 
-</div>
+    </div><!-- end detailed tab pane -->
+
+  </div><!-- end scrollable content wrapper -->
+
+</div><!-- end x-data summary block -->
 {% endif %}
 
 <!-- ================================================================
-     SMART CHAPTERS
+     FALLBACK: chapters only (no summaries at all)
      ================================================================ -->
-{% if has_chapters %}
-<div id="chapters-section" x-data="{ allExpanded: false }">
+{% if not has_summaries %}
+  {% if has_chapters %}
+  <div id="chapters-section" x-data="{ allExpanded: false }">
 
-  <!-- Section header with Expand/Collapse All -->
-  <div class="flex items-center justify-between mb-3">
-    <h2 class="text-xl font-bold text-slate-900">
-      Chapters
-      <span class="ml-2 text-sm font-normal text-slate-400">({{ chapters | length }})</span>
-    </h2>
-    <button
-      @click="allExpanded = !allExpanded"
-      class="flex items-center gap-1 text-xs text-slate-400 hover:text-brand-600 transition-colors focus:outline-none focus:ring-2 focus:ring-brand-400 rounded px-2 py-1"
-    >
-      <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-        <path x-show="!allExpanded" stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
-        <path x-show="allExpanded" x-cloak stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" />
-      </svg>
-      <span x-text="allExpanded ? 'Collapse all' : 'Expand all'"></span>
-    </button>
-  </div>
+    <!-- Section header with Expand/Collapse All -->
+    <div class="flex items-center justify-between mb-3">
+      <h2 class="text-xl font-bold text-slate-900">
+        Chapters
+        <span class="ml-2 text-sm font-normal text-slate-400">({{ chapters | length }})</span>
+      </h2>
+      <button
+        @click="allExpanded = !allExpanded"
+        class="flex items-center gap-1 text-xs text-slate-400 hover:text-brand-600 transition-colors focus:outline-none focus:ring-2 focus:ring-brand-400 rounded px-2 py-1"
+      >
+        <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path x-show="!allExpanded" stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+          <path x-show="allExpanded" x-cloak stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" />
+        </svg>
+        <span x-text="allExpanded ? 'Collapse all' : 'Expand all'"></span>
+      </button>
+    </div>
 
-  <!-- Mini timeline bar -->
-  {% if total_duration and total_duration > 0 %}
-  <div class="mb-5">
-    <div class="vs-timeline mb-1" role="group" aria-label="Video chapter timeline">
-      {% set tl_colors = ['#0284c7','#0369a1','#0ea5e9','#38bdf8','#7dd3fc','#2563eb','#1d4ed8','#3b82f6'] %}
+    <!-- Mini timeline bar -->
+    {% if total_duration and total_duration > 0 %}
+    <div class="mb-5">
+      <div class="vs-timeline mb-1" role="group" aria-label="Video chapter timeline">
+        {% set tl_colors = ['#0284c7','#0369a1','#0ea5e9','#38bdf8','#7dd3fc','#2563eb','#1d4ed8','#3b82f6'] %}
+        {% for chapter in chapters %}
+        {% set pct_left  = (chapter.start_time_sec / total_duration * 100) | round(2) %}
+        {% set pct_width = ((chapter.end_time_sec - chapter.start_time_sec) / total_duration * 100) | round(2) %}
+        {% set tl_color  = tl_colors[loop.index0 % (tl_colors | length)] %}
+        <div
+          class="vs-timeline-segment"
+          style="left:{{ pct_left }}%; width:{{ [pct_width, 1] | max }}%; background:{{ tl_color }};"
+          data-start="{{ chapter.start_time_sec }}"
+          data-chapter-id="{{ chapter.chapter_id }}"
+          title="Ch.{{ loop.index }}: {{ chapter.title }} ({{ chapter.start_display }})"
+          role="button"
+          tabindex="0"
+          aria-label="Jump to chapter {{ loop.index }}: {{ chapter.title }}"
+        ></div>
+        {% endfor %}
+      </div>
+      <div class="flex justify-between text-xs text-slate-400 px-0.5">
+        <span>0:00</span>
+        {% if video and video.duration_sec %}
+        <span>{{ (video.duration_sec // 60) }}:{{ '%02d' % (video.duration_sec % 60) }}</span>
+        {% endif %}
+      </div>
+    </div>
+    {% endif %}
+
+    <!-- Chapter cards list -->
+    <div class="space-y-3" id="chapter-list">
       {% for chapter in chapters %}
-      {% set pct_left  = (chapter.start_time_sec / total_duration * 100) | round(2) %}
-      {% set pct_width = ((chapter.end_time_sec - chapter.start_time_sec) / total_duration * 100) | round(2) %}
-      {% set tl_color  = tl_colors[loop.index0 % (tl_colors | length)] %}
-      <div
-        class="vs-timeline-segment"
-        style="left:{{ pct_left }}%; width:{{ [pct_width, 1] | max }}%; background:{{ tl_color }};"
-        data-start="{{ chapter.start_time_sec }}"
-        data-chapter-id="{{ chapter.chapter_id }}"
-        title="Ch.{{ loop.index }}: {{ chapter.title }} ({{ chapter.start_display }})"
-        role="button"
-        tabindex="0"
-        aria-label="Jump to chapter {{ loop.index }}: {{ chapter.title }}"
-      ></div>
+      {% set loop_index = loop.index %}
+      {% include "partials/chapter_card.html" %}
       {% endfor %}
     </div>
-    <div class="flex justify-between text-xs text-slate-400 px-0.5">
-      <span>0:00</span>
-      {% if video and video.duration_sec %}
-      <span>{{ (video.duration_sec // 60) }}:{{ '%02d' % (video.duration_sec % 60) }}</span>
-      {% endif %}
+
+  </div>
+  {% else %}
+  <!-- Neither available -->
+  <div class="flex flex-col items-center justify-center py-16 text-center">
+    <div class="w-12 h-12 bg-slate-100 rounded-full flex items-center justify-center mb-4">
+      <svg class="w-6 h-6 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+      </svg>
     </div>
+    <p class="text-slate-500 font-medium">No results available</p>
+    <p class="text-slate-400 text-sm mt-1">Try regenerating with a new focus prompt.</p>
   </div>
   {% endif %}
-
-  <!-- Chapter cards list -->
-  <div class="space-y-3" id="chapter-list">
-    {% for chapter in chapters %}
-    {% set loop_index = loop.index %}
-    {% include "partials/chapter_card.html" %}
-    {% endfor %}
-  </div>
-
-</div>
-{% elif not has_summaries %}
-<!-- Neither available -->
-<div class="flex flex-col items-center justify-center py-16 text-center">
-  <div class="w-12 h-12 bg-slate-100 rounded-full flex items-center justify-center mb-4">
-    <svg class="w-6 h-6 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-      <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-    </svg>
-  </div>
-  <p class="text-slate-500 font-medium">No results available</p>
-  <p class="text-slate-400 text-sm mt-1">Try regenerating with a new focus prompt.</p>
-</div>
-{% endif %}
-
-<!-- Chapters failed but summaries available -->
-{% if not has_chapters and has_summaries %}
-<div class="mt-5 flex items-start gap-3 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3.5 text-sm">
-  <svg class="w-4 h-4 mt-0.5 flex-shrink-0 text-amber-500" fill="currentColor" viewBox="0 0 20 20">
-    <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
-  </svg>
-  <div>
-    <p class="font-semibold text-amber-900">Chapter extraction was not completed</p>
-    <p class="text-amber-700 text-xs mt-0.5">Use the Regenerate button on the right to try again.</p>
-  </div>
-</div>
 {% endif %}
 
 <script>

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -269,6 +269,59 @@
   -webkit-line-clamp: 3;
 }
 
+/* Chapter summary paragraph inside unified expandable body */
+.vs-chapter-summary {
+  font-size: 0.8125rem;
+  color: #475569;
+  line-height: 1.65;
+  font-style: italic;
+}
+
+/* Active outline bullet — mirrors chapter card active state at smaller scale */
+.outline-point.is-active-bullet {
+  background-color: #f0f9ff;
+}
+
+.outline-point.is-active-bullet .outline-point-badge {
+  background-color: #0284c7;
+  color: #fff;
+  border-color: #0284c7;
+}
+
+.outline-point.is-active-bullet .outline-point-text {
+  color: #0c4a6e;
+  font-weight: 500;
+}
+
+.outline-point.is-active-bullet .vs-outline-point-ts {
+  color: #0284c7;
+}
+
+/* Per-bullet estimated timestamp chip — lighter weight than chapter separator chip */
+.vs-outline-point-ts {
+  font-family: ui-monospace, monospace;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  color: #94a3b8;
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color 0.12s ease;
+  line-height: 1.4;
+}
+
+.vs-outline-point-ts:hover {
+  color: #0284c7;
+}
+
+.vs-outline-point-ts:focus-visible {
+  outline: 2px solid #38bdf8;
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
 /* ============================================================
    Prose overrides for summary content
    ============================================================ */

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -154,6 +154,9 @@
     const cards = Array.from(document.querySelectorAll('.chapter-card'));
     if (!cards.length) return;
 
+    // Ensure the Detailed Outline tab is active so chapter cards are visible
+    ensureDetailedTabActive();
+
     const activeIdx = cards.findIndex(function (c) {
       return c.classList.contains('is-active-chapter');
     });
@@ -168,6 +171,20 @@
       window.seekVideo(start);
     }
     next.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }
+
+  /**
+   * Switch the summary tab to 'detailed' if the chapter explorer lives there
+   * and the current tab is something else. This ensures j/k navigation is
+   * meaningful — the user can see the card that gets highlighted.
+   */
+  function ensureDetailedTabActive() {
+    const summaryRoot = document.querySelector('[x-data*="activeTab"]');
+    if (!summaryRoot) return;
+    const data = summaryRoot._x_dataStack && summaryRoot._x_dataStack[0];
+    if (data && typeof data.activeTab !== 'undefined' && data.activeTab !== 'detailed') {
+      data.activeTab = 'detailed';
+    }
   }
 
   function togglePlayPause() {
@@ -202,6 +219,14 @@
       }
     }
   }
+
+  /**
+   * Expose tab-switcher globally so player.js can call it when
+   * auto-scrolling to an active chapter that lives inside the detailed tab.
+   */
+  window.vsEnsureDetailedTab = function () {
+    ensureDetailedTabActive();
+  };
 
   document.addEventListener('click', function (e) {
     const seg = e.target.closest('.vs-timeline-segment');

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -154,8 +154,7 @@
     const cards = Array.from(document.querySelectorAll('.chapter-card'));
     if (!cards.length) return;
 
-    // Ensure the Detailed Outline tab is active so chapter cards are visible
-    ensureDetailedTabActive();
+    const tabSwitched = ensureDetailedTabActive();
 
     const activeIdx = cards.findIndex(function (c) {
       return c.classList.contains('is-active-chapter');
@@ -170,7 +169,18 @@
     if (!isNaN(start) && window.seekVideo) {
       window.seekVideo(start);
     }
-    next.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    function scrollToCard() {
+      next.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+    if (tabSwitched) {
+      queueMicrotask(function () {
+        requestAnimationFrame(function () {
+          requestAnimationFrame(scrollToCard);
+        });
+      });
+    } else {
+      scrollToCard();
+    }
   }
 
   /**
@@ -178,13 +188,18 @@
    * and the current tab is something else. This ensures j/k navigation is
    * meaningful — the user can see the card that gets highlighted.
    */
+  /**
+   * @returns {boolean} true if the tab was switched to detailed (DOM not yet updated — Alpine batches)
+   */
   function ensureDetailedTabActive() {
     const summaryRoot = document.querySelector('[x-data*="activeTab"]');
-    if (!summaryRoot) return;
+    if (!summaryRoot) return false;
     const data = summaryRoot._x_dataStack && summaryRoot._x_dataStack[0];
     if (data && typeof data.activeTab !== 'undefined' && data.activeTab !== 'detailed') {
       data.activeTab = 'detailed';
+      return true;
     }
+    return false;
   }
 
   function togglePlayPause() {
@@ -223,9 +238,10 @@
   /**
    * Expose tab-switcher globally so player.js can call it when
    * auto-scrolling to an active chapter that lives inside the detailed tab.
+   * @returns {boolean} true if tab was just switched (caller should defer until layout)
    */
   window.vsEnsureDetailedTab = function () {
-    ensureDetailedTabActive();
+    return ensureDetailedTabActive();
   };
 
   document.addEventListener('click', function (e) {

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -18,6 +18,33 @@
   // transition (inactive→active), never on every tick.
   let lastActiveCard   = null;
   let lastActiveBullet = null;
+  /** Bumped on seek/pause to drop stale deferred scrolls; bumped when scheduling so newer work wins */
+  let scrollGen = 0;
+
+  function bumpScrollGen() {
+    scrollGen += 1;
+  }
+
+  /**
+   * After switching to Detailed tab, Alpine applies x-show on microtasks + layout on rAF.
+   * Run fn after that so scrollIntoView sees real geometry.
+   */
+  function runAfterDetailedTabLayout(tabJustSwitched, fn) {
+    const gen = ++scrollGen;
+    const run = function () {
+      if (gen !== scrollGen) return;
+      fn();
+    };
+    if (tabJustSwitched) {
+      queueMicrotask(function () {
+        requestAnimationFrame(function () {
+          requestAnimationFrame(run);
+        });
+      });
+    } else {
+      run();
+    }
+  }
 
   // Called by the YouTube IFrame API once it loads
   window.onYouTubeIframeAPIReady = function () {
@@ -54,6 +81,7 @@
       startHighlightLoop();
     } else {
       stopHighlightLoop();
+      bumpScrollGen();
       // Reset trackers so the next play/seek fires scroll immediately.
       lastActiveCard   = null;
       lastActiveBullet = null;
@@ -122,13 +150,15 @@
         //  - no bullet is already scrolling (bullets are finer-grained)
         //  - this is a new active card (transition, not every tick)
         if (isPlaying && !activeBulletFound && card !== lastActiveCard) {
-          lastActiveCard = card;
-          if (typeof window.vsEnsureDetailedTab === 'function') {
+          var switched =
+            typeof window.vsEnsureDetailedTab === 'function' &&
             window.vsEnsureDetailedTab();
-          }
-          if (!isCardVisible(card)) {
-            card.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-          }
+          runAfterDetailedTabLayout(switched, function () {
+            lastActiveCard = card;
+            if (!isCardVisible(card)) {
+              card.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+            }
+          });
         }
         if (segments[idx]) segments[idx].classList.add('is-active-segment');
       } else {
@@ -171,6 +201,7 @@
   /** Seek the player to a given timestamp in seconds. */
   window.seekVideo = function (seconds) {
     if (player && typeof player.seekTo === 'function') {
+      bumpScrollGen();
       // Reset trackers so the next poll tick scrolls to the new position.
       lastActiveCard   = null;
       lastActiveBullet = null;

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -14,6 +14,11 @@
   let highlightInterval = null;
   let isPlaying = false;
 
+  // Track the last element scrolled to so we only call scrollIntoView on
+  // transition (inactive→active), never on every tick.
+  let lastActiveCard   = null;
+  let lastActiveBullet = null;
+
   // Called by the YouTube IFrame API once it loads
   window.onYouTubeIframeAPIReady = function () {
     const container = document.getElementById('yt-player');
@@ -49,6 +54,9 @@
       startHighlightLoop();
     } else {
       stopHighlightLoop();
+      // Reset trackers so the next play/seek fires scroll immediately.
+      lastActiveCard   = null;
+      lastActiveBullet = null;
     }
   }
 
@@ -72,19 +80,55 @@
     if (!player || typeof player.getCurrentTime !== 'function') return;
     const currentTime = player.getCurrentTime();
 
+    // --- Bullets first: they are the finest-grained active element ---
+    // If a bullet is active, it handles scrolling; chapter-card scroll
+    // is suppressed to prevent the two from fighting each other.
+    let activeBulletFound = false;
+    const bullets = document.querySelectorAll('.outline-point');
+
+    bullets.forEach(function (bullet) {
+      const start    = parseInt(bullet.dataset.start, 10);
+      const end      = parseInt(bullet.dataset.end, 10);
+      const isActive = currentTime >= start && currentTime < end;
+
+      if (isActive) {
+        activeBulletFound = true;
+        bullet.classList.add('is-active-bullet');
+        // Scroll only on transition (bullet changed), not on every tick.
+        if (isPlaying && bullet !== lastActiveBullet) {
+          lastActiveBullet = bullet;
+          if (!isCardVisible(bullet)) {
+            bullet.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+          }
+        }
+      } else {
+        bullet.classList.remove('is-active-bullet');
+      }
+    });
+
+    // --- Chapter cards ---
     const cards    = document.querySelectorAll('.chapter-card');
     const segments = document.querySelectorAll('.vs-timeline-segment');
 
     cards.forEach(function (card, idx) {
-      const start   = parseInt(card.dataset.start, 10);
-      const end     = parseInt(card.dataset.end, 10);
+      const start    = parseInt(card.dataset.start, 10);
+      const end      = parseInt(card.dataset.end, 10);
       const isActive = currentTime >= start && currentTime < end;
 
       if (isActive) {
         card.classList.add('is-active-chapter');
-        // Auto-scroll only while playing and card is fully out of view
-        if (isPlaying && !isCardVisible(card)) {
-          card.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        // Only scroll to the chapter card when:
+        //  - playback is active
+        //  - no bullet is already scrolling (bullets are finer-grained)
+        //  - this is a new active card (transition, not every tick)
+        if (isPlaying && !activeBulletFound && card !== lastActiveCard) {
+          lastActiveCard = card;
+          if (typeof window.vsEnsureDetailedTab === 'function') {
+            window.vsEnsureDetailedTab();
+          }
+          if (!isCardVisible(card)) {
+            card.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+          }
         }
         if (segments[idx]) segments[idx].classList.add('is-active-segment');
       } else {
@@ -127,6 +171,9 @@
   /** Seek the player to a given timestamp in seconds. */
   window.seekVideo = function (seconds) {
     if (player && typeof player.seekTo === 'function') {
+      // Reset trackers so the next poll tick scrolls to the new position.
+      lastActiveCard   = null;
+      lastActiveBullet = null;
       player.seekTo(seconds, true);
       player.playVideo();
     }

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -38,6 +39,22 @@ def _make_llm(return_value):
     return llm
 
 
+def _make_session_factory():
+    """Return an async context-manager factory yielding a mock DB session."""
+    session = MagicMock()
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    execute_result = MagicMock()
+    execute_result.scalar_one_or_none = MagicMock(return_value=None)
+    session.execute = AsyncMock(return_value=execute_result)
+
+    @asynccontextmanager
+    async def factory():
+        yield session
+
+    return factory
+
+
 def _make_run():
     run = MagicMock()
     run.id = 1
@@ -59,14 +76,14 @@ def _make_session():
 @pytest.mark.asyncio
 async def test_validate_input_passes_with_transcript():
     ts = _make_transcript_source("Some transcript text.")
-    state = {"transcript_source": ts, "errors": []}
+    state = {"transcript_source": ts, "errors": [], "run_id": 1, "session_factory": _make_session_factory()}
     result = await validate_input_node(state)
     assert result.get("pipeline_failed") is False
 
 
 @pytest.mark.asyncio
 async def test_validate_input_fails_without_transcript():
-    state = {"transcript_source": None, "errors": []}
+    state = {"transcript_source": None, "errors": [], "run_id": 1, "session_factory": _make_session_factory()}
     result = await validate_input_node(state)
     assert result.get("pipeline_failed") is True
     assert len(result.get("errors", [])) > 0
@@ -75,7 +92,7 @@ async def test_validate_input_fails_without_transcript():
 @pytest.mark.asyncio
 async def test_validate_input_fails_with_empty_transcript():
     ts = _make_transcript_source("   ")
-    state = {"transcript_source": ts, "errors": []}
+    state = {"transcript_source": ts, "errors": [], "run_id": 1, "session_factory": _make_session_factory()}
     result = await validate_input_node(state)
     assert result.get("pipeline_failed") is True
 
@@ -100,6 +117,8 @@ async def test_gen_summaries_returns_result():
         "focus_prompt": None,
         "pipeline_failed": False,
         "errors": [],
+        "run_id": 1,
+        "session_factory": _make_session_factory(),
     }
     result = await gen_summaries_node(state)
     assert result["summary_result"] == expected
@@ -130,6 +149,8 @@ async def test_gen_summaries_records_error_on_failure():
         "focus_prompt": None,
         "pipeline_failed": False,
         "errors": [],
+        "run_id": 1,
+        "session_factory": _make_session_factory(),
     }
     result = await gen_summaries_node(state)
     assert result["summary_result"] is None
@@ -162,6 +183,8 @@ async def test_extract_chapters_returns_result():
         "focus_prompt": None,
         "pipeline_failed": False,
         "errors": [],
+        "run_id": 1,
+        "session_factory": _make_session_factory(),
     }
     result = await extract_chapters_node(state)
     assert result["chapters_result"] == expected


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Reworks the primary read-screen rendering and playback-linked auto-scroll/highlighting logic; regressions could affect seeking, active highlighting, or keyboard navigation, but changes are localized to templates and client JS.
> 
> **Overview**
> **Detailed Outline is restructured into a single unified per-chapter surface**: the `detailed` tab now renders a mini timeline plus a collapsible `chapter-card` list where each chapter contains its outline bullets (with estimated seekable timestamps), summary, key points, and transcript, removing the separate standalone chapters section when summaries are present.
> 
> Server-side `partial_status` now derives and passes `detailed_outline_groups`, proportionally distributing detailed outline points across chapters and generating per-point `data-start`/`data-end` ranges for playback tracking, with fallbacks for outline-only and chapters-only states.
> 
> Playback UX is updated to avoid scroll “bounce”: `player.js` tracks last active chapter/bullet and only scrolls on transitions, prioritizing active bullets over chapter cards, and can auto-switch to the `detailed` tab via a new `vsEnsureDetailedTab` hook used by both `player.js` and `j/k` navigation in `app.js`. Styling adds active-bullet and chapter-summary presentation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3e4713c5307db2081888b8c3341efbb174dea61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->