### PR TITLE
feat: use YouTube API instead of yt-dlp

### DIFF
--- a/.cursor/plans/migrate_youtube_api_a39c2355.plan.md
+++ b/.cursor/plans/migrate_youtube_api_a39c2355.plan.md
@@ -1,0 +1,162 @@
+---
+name: Migrate YouTube API
+overview: Replace yt-dlp with the official YouTube Data API v3 for metadata, add video tags/category/comments as LLM context, fix upload_date format, update language detection, and retain youtube-transcript-api for transcripts.
+todos:
+  - id: config-and-deps
+    content: Add youtube settings to config.py / .env.example; remove yt-dlp from pyproject.toml
+    status: completed
+  - id: db-schema
+    content: Add tags_json, top_comments_json, category to Video model + migration entries in database.py
+    status: completed
+  - id: youtube-service
+    content: Replace _fetch_metadata with async httpx calls to Data API v3 (videos.list + commentThreads.list); update _detect_language; add ISO 8601 duration parser
+    status: completed
+  - id: upload-date-migration
+    content: Store ISO 8601 publishedAt; update video_metadata.html template to parse both old YYYYMMDD and new ISO formats
+    status: completed
+  - id: llm-context
+    content: Add video_tags/video_comments/video_category to GraphState; inject into summary and chapter prompts
+    status: completed
+  - id: tests
+    content: "Rewrite test_youtube.py: replace yt-dlp mocks with httpx mocks; add ISO 8601 duration parser tests; add _detect_language tests for new API fields"
+    status: completed
+isProject: false
+---
+
+# Migrate YouTube Integration to Official API v3
+
+Replace the unofficial `yt-dlp` scraper (which triggers bot-detection on cloud/VM IPs) with the official YouTube Data API v3 for all metadata. Retain `youtube-transcript-api` for transcripts (the official Captions API requires OAuth2 as the video owner). Enrich LLM context with video tags, category, and top comments.
+
+## Key Design Decisions
+
+- **API key required at startup** -- app refuses to start without `YOUTUBE_API_KEY` (same pattern as `APP_SECRET_KEY`).
+- `**upload_date` stored as ISO 8601** going forward; template updated to handle both old `YYYYMMDD` rows and new ISO strings.
+- **Comments are best-effort** -- silently store `null` if disabled on a video (no user-visible warning).
+- **Comment injection into LLM prompts is configurable** via `youtube_max_comments` and `youtube_max_comment_chars` settings to control token budget.
+- **Video category** captured from `snippet.categoryId` (resolved to display name) for LLM domain hints.
+- **Language detection** uses `snippet.defaultAudioLanguage` (more reliable than yt-dlp's heuristic).
+
+## 1. Configuration and Dependencies
+
+**[app/config.py](app/config.py)** -- add to `Settings`:
+
+- `youtube_api_key: str` (required, validated non-empty; app refuses to start if missing)
+- `youtube_max_comments: int = 20` (how many top comments to fetch)
+- `youtube_max_comment_chars: int = 300` (per-comment truncation limit)
+
+**[.env.example](.env.example)** -- add `YOUTUBE_API_KEY=...` in a new "YouTube" section.
+
+**[pyproject.toml](pyproject.toml)** -- remove `yt-dlp` from `[project.dependencies]`. `httpx` is already present.
+
+## 2. Database Schema
+
+**[app/models/db.py](app/models/db.py)** -- add to `Video`:
+
+- `tags_json: Mapped[str | None] = mapped_column(Text)` -- JSON array of creator tags
+- `top_comments_json: Mapped[str | None] = mapped_column(Text)` -- JSON array of `{author, text}` dicts
+- `category: Mapped[str | None] = mapped_column(String(128))` -- resolved category name (e.g., "Education")
+
+**[app/database.py](app/database.py)** -- add migration entries to `_add_missing_columns`:
+
+```python
+("videos", "tags_json", "TEXT"),
+("videos", "top_comments_json", "TEXT"),
+("videos", "category", "VARCHAR(128)"),
+```
+
+Note: existing `upload_date` column is `String(20)` which is too short for ISO 8601 (`2024-01-15T12:00:00Z` = 20 chars). It fits exactly, but to be safe we should keep the existing column type since 20 chars accommodates the format.
+
+## 3. YouTube Service ([app/services/youtube.py](app/services/youtube.py))
+
+**Remove:** `import yt_dlp`, `_YDL_OPTS` dict, existing `_fetch_metadata()` function.
+
+**Add `_fetch_metadata(video_id)` (async):**
+
+- Call `https://www.googleapis.com/youtube/v3/videos?id={video_id}&part=snippet,contentDetails,statistics&key={api_key}` via `httpx.AsyncClient`.
+- Map response fields to a dict matching the keys `ingest_video` already uses:
+  - `title` from `snippet.title`
+  - `description` from `snippet.description`
+  - `thumbnail` from `snippet.thumbnails.high.url` (fallback: `.medium.url`, `.default.url`)
+  - `uploader` / `channel` from `snippet.channelTitle`
+  - `channel_url` from `https://www.youtube.com/channel/{snippet.channelId}`
+  - `upload_date` from `snippet.publishedAt` (ISO 8601, stored as-is)
+  - `duration` parsed from `contentDetails.duration` (ISO 8601 period, e.g., `PT1H2M3S` -> seconds)
+  - `view_count` from `statistics.viewCount` (int)
+  - `like_count` from `statistics.likeCount` (int)
+  - `tags` from `snippet.tags` (list of strings, stored as JSON)
+  - `category` resolved from `snippet.categoryId` via `videoCategories.list` or a static lookup map
+  - `language` from `snippet.defaultAudioLanguage` (fallback: `snippet.defaultLanguage`)
+- Return `IngestionError(error_code="METADATA_FETCH_FAILED", ...)` on HTTP errors or empty `items[]`.
+
+**Add `_parse_iso8601_duration(iso_str)` helper:**
+
+- Parse `PT(\d+H)?(\d+M)?(\d+S)?` -> total seconds. Handle edge cases (`P0D`, `PT0S`, missing components).
+
+**Update `_detect_language(info)`:**
+
+- Primary: read `language` key (now populated from `snippet.defaultAudioLanguage`).
+- Fallback: keep existing subtitles/captions heuristic for backward compatibility with cached data.
+
+**Add `_fetch_top_comments(video_id)` (async):**
+
+- Call `https://www.googleapis.com/youtube/v3/commentThreads?videoId={video_id}&part=snippet&order=relevance&maxResults={settings.youtube_max_comments}&key={api_key}`.
+- Extract `{author, text}` from each `snippet.topLevelComment.snippet`.
+- Truncate each `text` to `settings.youtube_max_comment_chars`.
+- On 403 `commentsDisabled` or any error: return `None` silently (best-effort).
+
+**Update `ingest_video()`:**
+
+- Change `_fetch_metadata` call to `await _fetch_metadata(video_id)` (now async -- no thread executor needed).
+- After metadata, call `await _fetch_top_comments(video_id)`.
+- Store `tags_json`, `top_comments_json`, and `category` on the `Video` object.
+
+## 4. Upload Date Template Fix
+
+**[app/templates/partials/video_metadata.html](app/templates/partials/video_metadata.html)** (lines 56-64):
+
+- Update the Jinja2 date formatting block to handle both:
+  - Legacy `YYYYMMDD` (8 chars, existing DB rows)
+  - New ISO 8601 `YYYY-MM-DDTHH:MM:SSZ` (contains `-` and `T`)
+- Detection: if `yd` contains `T`, parse as ISO 8601; else use existing `length == 8` logic.
+
+## 5. LLM Context Enhancements
+
+**[app/services/llm/state.py](app/services/llm/state.py)** -- add to `GraphState`:
+
+- `video_tags: Any` -- `list[str] | None`
+- `video_comments: Any` -- `list[dict] | None`
+- `video_category: Any` -- `str | None`
+
+**[app/services/llm/graph.py](app/services/llm/graph.py)** -- in `run_pipeline()`, populate new state keys from `Video` model fields (parse `tags_json` and `top_comments_json` from JSON).
+
+**[app/services/llm/prompts.py](app/services/llm/prompts.py)** -- add a `<video_context>` block injected into summary and chapter system prompts when tags/comments/category are available:
+
+```
+<video_context>
+Category: {category}
+Creator tags: {comma-separated tags}
+Top viewer comments (for audience sentiment context):
+- "{comment_1}"
+- "{comment_2}"
+...
+</video_context>
+```
+
+Only include sections that have data. This block is appended after the existing system prompt and before any `<user_focus>` block.
+
+## 6. Testing
+
+**[tests/test_youtube.py](tests/test_youtube.py)**:
+
+- Remove all `yt-dlp` mock references.
+- Add `TestFetchMetadata` class: mock `httpx.AsyncClient.get` to return sample `videos.list` JSON; verify field mapping, error handling for 403/404, empty items array.
+- Add `TestParseIsoDuration`: cover `PT1H2M3S`, `PT5M`, `PT30S`, `P0D`, `PT0S`, malformed strings.
+- Update `TestDetectLanguage`: test with new `defaultAudioLanguage`-style data.
+- Add `TestFetchTopComments`: mock `commentThreads.list` response; verify truncation; verify graceful handling of `commentsDisabled` 403.
+
+## Risks and Mitigations
+
+- **YouTube Data API v3 quota**: Default is 10,000 units/day. `videos.list` = 1 unit, `commentThreads.list` = 1 unit. At 2 units per video analyzed, this supports ~5,000 videos/day. Monitor via GCP console; request quota increase if needed.
+- `**youtube-transcript-api` may also face throttling on datacenter IPs**: Less aggressive than yt-dlp but still possible. If this becomes an issue, a future enhancement could add configurable proxy support or cookie injection specifically for the transcript library.
+- **Cached videos with old yt-dlp data**: Existing DB rows will have `YYYYMMDD` upload dates, no tags/comments/category. The template and LLM prompts must handle `null` gracefully (already addressed above).
+

--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,12 @@ ANTHROPIC_API_KEY=sk-ant-...
 # Ollama (if using local models)
 OLLAMA_BASE_URL=http://localhost:11434
 
+# YouTube Data API v3 (REQUIRED)
+# Obtain from Google Cloud Console: https://console.cloud.google.com/apis/credentials
+YOUTUBE_API_KEY=...
+# YOUTUBE_MAX_COMMENTS=20
+# YOUTUBE_MAX_COMMENT_CHARS=300
+
 # Database (stored under data/ with embeddings)
 DATABASE_URL=sqlite+aiosqlite:///./data/vidsense.db
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ This project uses [uv](https://docs.astral.sh/uv/) for dependency management and
 # Create virtual environment and install dependencies
 uv sync
 
-# Copy environment template and add at least one provider API key (or use Ollama)
+# Copy environment template: add at least one LLM provider API key (or use Ollama),
+# and YOUTUBE_API_KEY (required — see "YouTube Data API key" below)
 cp .env.example .env
 # Edit .env — see comments in .env.example
 
@@ -49,6 +50,15 @@ uv run uvicorn main:app --reload
 ```
 
 With `APP_DEBUG=true` in `.env`, `python main.py` enables uvicorn reload when run via the `__main__` block.
+
+### YouTube Data API key
+
+**Required.** VidSense calls the [YouTube Data API v3](https://developers.google.com/youtube/v3/getting-started) for video metadata (title, duration, thumbnails, tags, category, and optional top comments for LLM context). Set **`YOUTUBE_API_KEY`** in `.env`; the app refuses to start without it (same idea as `APP_SECRET_KEY`).
+
+- **Create a key:** open [Google Cloud Console → APIs & Credentials](https://console.cloud.google.com/apis/credentials), select or create a project, enable **YouTube Data API v3** for that project, then create an **API key** and paste it as `YOUTUBE_API_KEY`.
+- **Optional:** `YOUTUBE_MAX_COMMENTS` (default `20`) and `YOUTUBE_MAX_COMMENT_CHARS` (default `300`) limit how many top comments are fetched and how long each comment snippet is when passed to the model.
+
+See also the **YouTube** block in [`.env.example`](./.env.example).
 
 ---
 
@@ -72,7 +82,7 @@ Create a local `.env` file before running the app:
 cp .env.example .env
 ```
 
-Then configure at least one LLM provider API key, or point VidSense at a local Ollama instance. The main settings live in `app/config.py`, and `.env.example` documents the expected variables.
+Then configure at least one LLM provider API key (or point VidSense at a local Ollama instance) **and** `YOUTUBE_API_KEY` as described in [YouTube Data API key](#youtube-data-api-key) above. The main settings live in `app/config.py`, and `.env.example` documents the expected variables.
 
 ### Run the test suite
 

--- a/app/config.py
+++ b/app/config.py
@@ -77,6 +77,11 @@ class Settings(BaseSettings):
         ),
     )
 
+    # YouTube Data API v3
+    youtube_api_key: str = Field(default="", description="YouTube Data API v3 key (required)")
+    youtube_max_comments: int = Field(default=20, description="Top comments to fetch per video")
+    youtube_max_comment_chars: int = Field(default=300, description="Per-comment character truncation limit")
+
     # Processing limits
     max_video_duration_sec: int = Field(default=5400, description="90 minutes in seconds")
     supported_languages: list[str] = Field(

--- a/app/database.py
+++ b/app/database.py
@@ -47,6 +47,9 @@ async def _add_missing_columns(conn) -> None:
         ("videos", "upload_date", "VARCHAR(20)"),
         ("videos", "view_count", "INTEGER"),
         ("videos", "like_count", "INTEGER"),
+        ("videos", "tags_json", "TEXT"),
+        ("videos", "top_comments_json", "TEXT"),
+        ("videos", "category", "VARCHAR(128)"),
     ]
     for table, column, col_type in migrations:
         try:

--- a/app/models/db.py
+++ b/app/models/db.py
@@ -51,6 +51,9 @@ class Video(Base):
     upload_date: Mapped[str | None] = mapped_column(String(20))
     view_count: Mapped[int | None] = mapped_column(Integer)
     like_count: Mapped[int | None] = mapped_column(Integer)
+    tags_json: Mapped[str | None] = mapped_column(Text)
+    top_comments_json: Mapped[str | None] = mapped_column(Text)
+    category: Mapped[str | None] = mapped_column(String(128))
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
 
     transcript_sources: Mapped[list["TranscriptSource"]] = relationship(

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -170,7 +170,7 @@ async def _run_pipeline_bg(
 ) -> None:
     """Background task: runs the pipeline with a fresh DB session."""
     from app.database import AsyncSessionLocal
-    from app.models.db import AnalysisRun, TranscriptSource
+    from app.models.db import AnalysisRun, TranscriptSource, Video
 
     try:
         async with AsyncSessionLocal() as session:
@@ -188,10 +188,14 @@ async def _run_pipeline_bg(
                 )
                 return
 
+            video_result = await session.execute(select(Video).where(Video.id == run.video_id))
+            video = video_result.scalar_one_or_none()
+
             await start_analysis(
                 run=run,
                 transcript_source=transcript_source,
                 session=session,
+                video=video,
             )
     except Exception as exc:
         logger.exception("Background task for run %d failed unexpectedly: %s", run_id, exc)

--- a/app/services/llm/graph.py
+++ b/app/services/llm/graph.py
@@ -15,12 +15,13 @@ different tasks can use different models without sharing state.
 """
 from __future__ import annotations
 
+import json
 import logging
 
 from langgraph.graph import END, START, StateGraph
 
 from app.lang import normalize_language_code
-from app.models.db import AnalysisRun, TranscriptSource
+from app.models.db import AnalysisRun, TranscriptSource, Video
 from app.services.llm.nodes import (
     embed_transcript_node,
     extract_chapters_node,
@@ -80,6 +81,7 @@ async def run_pipeline(
     run: AnalysisRun,
     transcript_source: TranscriptSource,
     focus_prompt: str | None = None,
+    video: Video | None = None,
 ) -> GraphState:
     """
     Execute the full VidSense processing pipeline.
@@ -91,6 +93,22 @@ async def run_pipeline(
     Each node constructs its own LLM via get_llm(task=...) so per-task model
     overrides are respected without passing a shared LLM through state.
     """
+    video_tags: list[str] | None = None
+    video_comments: list[dict] | None = None
+    video_category: str | None = None
+    if video:
+        if video.tags_json:
+            try:
+                video_tags = json.loads(video.tags_json)
+            except (json.JSONDecodeError, TypeError):
+                pass
+        if video.top_comments_json:
+            try:
+                video_comments = json.loads(video.top_comments_json)
+            except (json.JSONDecodeError, TypeError):
+                pass
+        video_category = video.category
+
     initial_state: GraphState = {
         "session_factory": session_factory,
         "run_id": run.id,
@@ -98,6 +116,9 @@ async def run_pipeline(
         "transcript_source": transcript_source,
         "focus_prompt": focus_prompt,
         "language_code": normalize_language_code(transcript_source.language_code),
+        "video_tags": video_tags,
+        "video_comments": video_comments,
+        "video_category": video_category,
         "errors": [],
         "pipeline_failed": False,
         "summary_result": None,

--- a/app/services/llm/nodes.py
+++ b/app/services/llm/nodes.py
@@ -188,7 +188,13 @@ async def gen_summaries_node(state: GraphState) -> dict:
 
     language_code = state.get("language_code", "en")
     transcript_text = transcript_source.raw_text
-    messages = build_summary_messages(transcript_text, focus_prompt, language_code=language_code)
+    messages = build_summary_messages(
+        transcript_text, focus_prompt,
+        language_code=language_code,
+        video_tags=state.get("video_tags"),
+        video_comments=state.get("video_comments"),
+        video_category=state.get("video_category"),
+    )
 
     logger.info("[run=%d] gen_summaries: invoking LLM for 3-level summary", run_id)
     result, error = await _invoke_with_structured_output(
@@ -259,7 +265,13 @@ async def extract_chapters_node(state: GraphState) -> dict:
     if raw_len <= _CHAR_THRESHOLD_FOR_CHUNKING or not segments:
         logger.info("[run=%d] extract_chapters: single-pass extraction", run_id)
         formatted = format_transcript_with_timestamps(segments) if segments else transcript_source.raw_text
-        messages = build_chapter_messages(formatted, focus_prompt, language_code=language_code)
+        messages = build_chapter_messages(
+            formatted, focus_prompt,
+            language_code=language_code,
+            video_tags=state.get("video_tags"),
+            video_comments=state.get("video_comments"),
+            video_category=state.get("video_category"),
+        )
         result, error = await _invoke_with_structured_output(
             llm, ChapterListSchema, messages, settings.llm_max_retries
         )
@@ -312,6 +324,9 @@ async def extract_chapters_node(state: GraphState) -> dict:
         messages = build_chapter_messages_chunk(
             formatted_chunk, i + 1, total, start_str, end_str, focus_prompt,
             language_code=language_code,
+            video_tags=state.get("video_tags"),
+            video_comments=state.get("video_comments"),
+            video_category=state.get("video_category"),
         )
         result, error = await _invoke_with_structured_output(
             llm, ChapterListSchema, messages, settings.llm_max_retries

--- a/app/services/llm/prompts.py
+++ b/app/services/llm/prompts.py
@@ -32,6 +32,27 @@ def _maybe_language_hint(system: str, language_code: str) -> str:
     name = language_display_name(language_code)
     return system + _LANGUAGE_HINT.format(lang_name=name, lang_code=language_code)
 
+
+def _build_video_context(
+    tags: list[str] | None = None,
+    comments: list[dict] | None = None,
+    category: str | None = None,
+) -> str:
+    """Build an optional ``<video_context>`` block for system prompts."""
+    parts: list[str] = []
+    if category:
+        parts.append(f"Category: {category}")
+    if tags:
+        parts.append(f"Creator tags: {', '.join(tags[:30])}")
+    if comments:
+        lines = [f'- "{c.get("text", "")}"' for c in comments[:20] if c.get("text")]
+        if lines:
+            parts.append("Top viewer comments (for audience sentiment context):\n" + "\n".join(lines))
+    if not parts:
+        return ""
+    return "\n<video_context>\n" + "\n".join(parts) + "\n</video_context>\n"
+
+
 # ---------------------------------------------------------------------------
 # Summary prompts
 # ---------------------------------------------------------------------------
@@ -83,9 +104,18 @@ Please summarise the following transcript:
 
 
 def build_summary_messages(
-    transcript: str, focus_prompt: str | None = None, *, language_code: str = "en",
+    transcript: str,
+    focus_prompt: str | None = None,
+    *,
+    language_code: str = "en",
+    video_tags: list[str] | None = None,
+    video_comments: list[dict] | None = None,
+    video_category: str | None = None,
 ) -> list:
     system_content = _SUMMARY_SYSTEM
+    ctx = _build_video_context(video_tags, video_comments, video_category)
+    if ctx:
+        system_content += ctx
     if focus_prompt and focus_prompt.strip():
         system_content += _SUMMARY_FOCUS_ADDON.format(focus_prompt=focus_prompt.strip())
     system_content = _maybe_language_hint(system_content, language_code)
@@ -161,9 +191,18 @@ The start/end times are absolute seconds from the beginning of the video.
 
 
 def build_chapter_messages(
-    transcript: str, focus_prompt: str | None = None, *, language_code: str = "en",
+    transcript: str,
+    focus_prompt: str | None = None,
+    *,
+    language_code: str = "en",
+    video_tags: list[str] | None = None,
+    video_comments: list[dict] | None = None,
+    video_category: str | None = None,
 ) -> list:
     system_content = _CHAPTER_SYSTEM
+    ctx = _build_video_context(video_tags, video_comments, video_category)
+    if ctx:
+        system_content += ctx
     if focus_prompt and focus_prompt.strip():
         system_content += _CHAPTER_FOCUS_ADDON.format(focus_prompt=focus_prompt.strip())
     system_content = _maybe_language_hint(system_content, language_code)
@@ -182,8 +221,14 @@ def build_chapter_messages_chunk(
     focus_prompt: str | None = None,
     *,
     language_code: str = "en",
+    video_tags: list[str] | None = None,
+    video_comments: list[dict] | None = None,
+    video_category: str | None = None,
 ) -> list:
     system_content = _CHAPTER_SYSTEM
+    ctx = _build_video_context(video_tags, video_comments, video_category)
+    if ctx:
+        system_content += ctx
     if focus_prompt and focus_prompt.strip():
         system_content += _CHAPTER_FOCUS_ADDON.format(focus_prompt=focus_prompt.strip())
     system_content = _maybe_language_hint(system_content, language_code)

--- a/app/services/llm/state.py
+++ b/app/services/llm/state.py
@@ -21,6 +21,9 @@ class GraphState(TypedDict, total=False):
     transcript_source: Any  # TranscriptSource
     focus_prompt: Any  # str | None
     language_code: Any  # str — normalized ISO 639-1 code of the transcript
+    video_tags: Any       # list[str] | None — creator tags from YouTube API
+    video_comments: Any   # list[dict] | None — top comments from YouTube API
+    video_category: Any   # str | None — resolved category name
 
     # Intermediate results — summaries & chapters (V1)
     summary_result: Any    # SummarySchema | None

--- a/app/services/processing.py
+++ b/app/services/processing.py
@@ -15,7 +15,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import AsyncSessionLocal
-from app.models.db import AnalysisRun, AnalysisRunStatus, TranscriptSource
+from app.models.db import AnalysisRun, AnalysisRunStatus, TranscriptSource, Video
 from app.services.llm.graph import run_pipeline
 
 logger = logging.getLogger(__name__)
@@ -25,6 +25,7 @@ async def start_analysis(
     run: AnalysisRun,
     transcript_source: TranscriptSource,
     session: AsyncSession,
+    video: Video | None = None,
 ) -> AnalysisRun:
     """
     Mark an existing pending AnalysisRun as processing and run the pipeline.
@@ -45,6 +46,7 @@ async def start_analysis(
             run=run,
             transcript_source=transcript_source,
             focus_prompt=run.focus_prompt,
+            video=video,
         )
     except Exception as exc:
         logger.exception("[run=%d] Unhandled pipeline error: %s", run_id, exc)

--- a/app/services/youtube.py
+++ b/app/services/youtube.py
@@ -3,7 +3,7 @@ YouTube ingestion service.
 
 Responsibilities:
 - Parse and validate YouTube URLs
-- Fetch video metadata via yt-dlp
+- Fetch video metadata via YouTube Data API v3
 - Retrieve available transcripts via youtube-transcript-api
 - Cache Video + TranscriptSource in DB to avoid re-ingestion
 - Return typed results for all failure states
@@ -16,9 +16,7 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
-logger = logging.getLogger(__name__)
-
-import yt_dlp
+import httpx
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from youtube_transcript_api import (
@@ -38,6 +36,8 @@ from app.models.db import (
     Video,
 )
 from app.models.schemas import IngestionError
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # URL parsing
@@ -79,29 +79,67 @@ class IngestionResult:
     video: Video | None = None
     transcript_source: TranscriptSource | None = None
     error: IngestionError | None = None
-    quality_warning: str | None = None  # non-fatal warning to surface in UI
+    quality_warning: str | None = None
 
 
 # ---------------------------------------------------------------------------
-# Metadata fetch
+# YouTube Data API v3 helpers
 # ---------------------------------------------------------------------------
 
-_YDL_OPTS: dict[str, Any] = {
-    "quiet": True,
-    "no_warnings": True,
-    "skip_download": True,
-    "extract_flat": False,
-    "cachedir": False,
+_YT_API_BASE = "https://www.googleapis.com/youtube/v3"
+
+# YouTube video category IDs -> display names (YouTube's fixed set)
+_CATEGORY_MAP: dict[str, str] = {
+    "1": "Film & Animation", "2": "Autos & Vehicles", "10": "Music",
+    "15": "Pets & Animals", "17": "Sports", "18": "Short Movies",
+    "19": "Travel & Events", "20": "Gaming", "21": "Videoblogging",
+    "22": "People & Blogs", "23": "Comedy", "24": "Entertainment",
+    "25": "News & Politics", "26": "Howto & Style", "27": "Education",
+    "28": "Science & Technology", "29": "Nonprofits & Activism",
+    "30": "Movies", "31": "Anime/Animation", "32": "Action/Adventure",
+    "33": "Classics", "34": "Comedy", "35": "Documentary", "36": "Drama",
+    "37": "Family", "38": "Foreign", "39": "Horror", "40": "Sci-Fi/Fantasy",
+    "41": "Thriller", "42": "Shorts", "43": "Shows", "44": "Trailers",
 }
 
+_ISO_DURATION_RE = re.compile(
+    r"^P(?:(\d+)D)?T?(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$"
+)
 
-def _fetch_metadata(video_id: str) -> dict[str, Any] | IngestionError:
-    """Use yt-dlp to fetch video metadata synchronously (run in thread)."""
-    url = f"https://www.youtube.com/watch?v={video_id}"
+
+def _parse_iso8601_duration(iso_str: str) -> int | None:
+    """Parse an ISO 8601 duration like ``PT1H2M3S`` into total seconds."""
+    if not iso_str:
+        return None
+    m = _ISO_DURATION_RE.match(iso_str)
+    if not m:
+        return None
+    days = int(m.group(1) or 0)
+    hours = int(m.group(2) or 0)
+    minutes = int(m.group(3) or 0)
+    seconds = int(m.group(4) or 0)
+    return days * 86400 + hours * 3600 + minutes * 60 + seconds
+
+
+async def _fetch_metadata(video_id: str) -> dict[str, Any] | IngestionError:
+    """Fetch video metadata from YouTube Data API v3."""
+    url = (
+        f"{_YT_API_BASE}/videos"
+        f"?id={video_id}"
+        f"&part=snippet,contentDetails,statistics"
+        f"&key={settings.youtube_api_key}"
+    )
     try:
-        with yt_dlp.YoutubeDL(_YDL_OPTS) as ydl:
-            info = ydl.extract_info(url, download=False)
-            return info  # type: ignore[return-value]
+        async with httpx.AsyncClient(timeout=15) as client:
+            resp = await client.get(url)
+            resp.raise_for_status()
+            data = resp.json()
+    except httpx.HTTPStatusError as exc:
+        return IngestionError(
+            error_code="METADATA_FETCH_FAILED",
+            message=f"YouTube API returned {exc.response.status_code}: {exc.response.text[:200]}",
+            recoverable=exc.response.status_code >= 500,
+        )
     except Exception as exc:
         return IngestionError(
             error_code="METADATA_FETCH_FAILED",
@@ -109,18 +147,91 @@ def _fetch_metadata(video_id: str) -> dict[str, Any] | IngestionError:
             recoverable=True,
         )
 
+    items = data.get("items", [])
+    if not items:
+        return IngestionError(
+            error_code="METADATA_FETCH_FAILED",
+            message="Video not found or is unavailable.",
+            recoverable=False,
+        )
+
+    item = items[0]
+    snippet = item.get("snippet", {})
+    content_details = item.get("contentDetails", {})
+    statistics = item.get("statistics", {})
+
+    thumbnails = snippet.get("thumbnails", {})
+    thumbnail_url = (
+        thumbnails.get("high", {}).get("url")
+        or thumbnails.get("medium", {}).get("url")
+        or thumbnails.get("default", {}).get("url")
+    )
+
+    category_id = snippet.get("categoryId", "")
+    category = _CATEGORY_MAP.get(category_id)
+
+    duration_sec = _parse_iso8601_duration(content_details.get("duration", ""))
+
+    view_count_raw = statistics.get("viewCount")
+    like_count_raw = statistics.get("likeCount")
+
+    return {
+        "title": snippet.get("title"),
+        "description": snippet.get("description"),
+        "thumbnail": thumbnail_url,
+        "channel": snippet.get("channelTitle"),
+        "channel_url": f"https://www.youtube.com/channel/{snippet['channelId']}" if snippet.get("channelId") else None,
+        "upload_date": snippet.get("publishedAt"),
+        "duration": duration_sec,
+        "view_count": int(view_count_raw) if view_count_raw else None,
+        "like_count": int(like_count_raw) if like_count_raw else None,
+        "tags": snippet.get("tags", []),
+        "category": category,
+        "language": snippet.get("defaultAudioLanguage") or snippet.get("defaultLanguage"),
+    }
+
 
 def _detect_language(info: dict[str, Any]) -> str | None:
-    """Best-effort language detection from yt-dlp metadata."""
+    """Best-effort language detection from API metadata."""
     lang = info.get("language")
     if isinstance(lang, str) and lang.strip():
         return normalize_language_code(lang)
-    for key in ("subtitles", "automatic_captions"):
-        captions = info.get(key, {})
-        if isinstance(captions, dict) and captions:
-            first_lang = next(iter(captions))
-            return normalize_language_code(first_lang)
     return None
+
+
+async def _fetch_top_comments(video_id: str) -> list[dict[str, str]] | None:
+    """Fetch top comments via YouTube Data API v3 (best-effort, returns None on failure)."""
+    url = (
+        f"{_YT_API_BASE}/commentThreads"
+        f"?videoId={video_id}"
+        f"&part=snippet"
+        f"&order=relevance"
+        f"&maxResults={settings.youtube_max_comments}"
+        f"&key={settings.youtube_api_key}"
+    )
+    try:
+        async with httpx.AsyncClient(timeout=15) as client:
+            resp = await client.get(url)
+            resp.raise_for_status()
+            data = resp.json()
+    except Exception:
+        logger.debug("Comments fetch failed for video %s (best-effort, skipping)", video_id)
+        return None
+
+    comments: list[dict[str, str]] = []
+    max_chars = settings.youtube_max_comment_chars
+    for item in data.get("items", []):
+        try:
+            top = item["snippet"]["topLevelComment"]["snippet"]
+            text = (top.get("textDisplay") or "").strip()
+            if text:
+                comments.append({
+                    "author": top.get("authorDisplayName", ""),
+                    "text": text[:max_chars],
+                })
+        except (KeyError, TypeError):
+            continue
+    return comments or None
 
 
 # ---------------------------------------------------------------------------
@@ -260,10 +371,11 @@ async def ingest_video(
     Full ingestion pipeline:
     1. Parse URL
     2. Check cache (return existing Video + TranscriptSource if found)
-    3. Fetch metadata
+    3. Fetch metadata via YouTube Data API v3
     4. Validate duration + language
     5. Fetch transcript
-    6. Persist Video + TranscriptSource
+    6. Fetch top comments (best-effort)
+    7. Persist Video + TranscriptSource
     """
     # 1. Parse URL
     video_id = extract_video_id(url)
@@ -289,9 +401,8 @@ async def ingest_video(
                 quality_warning=quality_warning,
             )
 
-    # 3. Fetch metadata (blocking I/O — run in thread executor in production;
-    #    acceptable synchronous call here since yt-dlp has no async API)
-    metadata = _fetch_metadata(video_id)
+    # 3. Fetch metadata via YouTube Data API v3
+    metadata = await _fetch_metadata(video_id)
     if isinstance(metadata, IngestionError):
         return IngestionResult(success=False, error=metadata)
 
@@ -321,7 +432,11 @@ async def ingest_video(
     segments, source_type, lang_code = transcript_result
     raw_text = _build_raw_text(segments)
 
-    # 6. Persist
+    # 6. Fetch top comments (best-effort — None if disabled or errored)
+    comments = await _fetch_top_comments(video_id)
+
+    # 7. Persist
+    tags = metadata.get("tags", [])
     video = existing_video or Video(
         youtube_id=video_id,
         url=url,
@@ -329,12 +444,15 @@ async def ingest_video(
         duration_sec=duration_sec,
         language=lang_code or detected_lang,
         thumbnail_url=metadata.get("thumbnail"),
-        channel_name=metadata.get("uploader") or metadata.get("channel"),
-        channel_url=metadata.get("channel_url") or metadata.get("uploader_url"),
+        channel_name=metadata.get("channel"),
+        channel_url=metadata.get("channel_url"),
         description=metadata.get("description"),
         upload_date=metadata.get("upload_date"),
         view_count=metadata.get("view_count"),
         like_count=metadata.get("like_count"),
+        tags_json=json.dumps(tags) if tags else None,
+        top_comments_json=json.dumps(comments) if comments else None,
+        category=metadata.get("category"),
     )
     if not existing_video:
         session.add(video)

--- a/app/services/youtube.py
+++ b/app/services/youtube.py
@@ -136,10 +136,15 @@ async def _fetch_metadata(video_id: str) -> dict[str, Any] | IngestionError:
             resp.raise_for_status()
             data = resp.json()
     except httpx.HTTPStatusError as exc:
+        status = exc.response.status_code
+        # Treat YouTube API's transient statuses (quotaExceeded / rateLimitExceeded
+        # are returned as 403; 429 is short-term throttling; 5xx are server errors)
+        # as recoverable so the UI offers "try again later" rather than a dead end.
+        recoverable = status == 403 or status == 429 or status >= 500
         return IngestionError(
             error_code="METADATA_FETCH_FAILED",
-            message=f"YouTube API returned {exc.response.status_code}: {exc.response.text[:200]}",
-            recoverable=exc.response.status_code >= 500,
+            message=f"YouTube API returned {status}: {exc.response.text[:200]}",
+            recoverable=recoverable,
         )
     except Exception as exc:
         return IngestionError(

--- a/app/services/youtube.py
+++ b/app/services/youtube.py
@@ -123,15 +123,16 @@ def _parse_iso8601_duration(iso_str: str) -> int | None:
 
 async def _fetch_metadata(video_id: str) -> dict[str, Any] | IngestionError:
     """Fetch video metadata from YouTube Data API v3."""
-    url = (
-        f"{_YT_API_BASE}/videos"
-        f"?id={video_id}"
-        f"&part=snippet,contentDetails,statistics"
-        f"&key={settings.youtube_api_key}"
-    )
+    # Pass key via params (not URL string) so it never appears in exception
+    # reprs, access logs, or str(request.url) in future middleware.
+    params = {
+        "id": video_id,
+        "part": "snippet,contentDetails,statistics",
+        "key": settings.youtube_api_key,
+    }
     try:
         async with httpx.AsyncClient(timeout=15) as client:
-            resp = await client.get(url)
+            resp = await client.get(f"{_YT_API_BASE}/videos", params=params)
             resp.raise_for_status()
             data = resp.json()
     except httpx.HTTPStatusError as exc:
@@ -201,17 +202,16 @@ def _detect_language(info: dict[str, Any]) -> str | None:
 
 async def _fetch_top_comments(video_id: str) -> list[dict[str, str]] | None:
     """Fetch top comments via YouTube Data API v3 (best-effort, returns None on failure)."""
-    url = (
-        f"{_YT_API_BASE}/commentThreads"
-        f"?videoId={video_id}"
-        f"&part=snippet"
-        f"&order=relevance"
-        f"&maxResults={settings.youtube_max_comments}"
-        f"&key={settings.youtube_api_key}"
-    )
+    params = {
+        "videoId": video_id,
+        "part": "snippet",
+        "order": "relevance",
+        "maxResults": settings.youtube_max_comments,
+        "key": settings.youtube_api_key,
+    }
     try:
         async with httpx.AsyncClient(timeout=15) as client:
-            resp = await client.get(url)
+            resp = await client.get(f"{_YT_API_BASE}/commentThreads", params=params)
             resp.raise_for_status()
             data = resp.json()
     except Exception:

--- a/app/templates/partials/video_metadata.html
+++ b/app/templates/partials/video_metadata.html
@@ -56,7 +56,12 @@
       {% if video.upload_date %}
       {% set yd = video.upload_date %}
       {% set months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'] %}
-      {% if yd | length == 8 %}
+      {% if 'T' in yd %}
+        {# ISO 8601: 2024-01-15T12:00:00Z #}
+        {% set month_idx = (yd[5:7] | int) - 1 %}
+        {% set upload_formatted = months[month_idx] ~ ' ' ~ (yd[8:10] | int) ~ ', ' ~ yd[0:4] %}
+      {% elif yd | length == 8 %}
+        {# Legacy YYYYMMDD from yt-dlp era #}
         {% set month_idx = (yd[4:6] | int) - 1 %}
         {% set upload_formatted = months[month_idx] ~ ' ' ~ (yd[6:8] | int) ~ ', ' ~ yd[0:4] %}
       {% else %}

--- a/docs/deployment-aws.md
+++ b/docs/deployment-aws.md
@@ -187,6 +187,9 @@ APP_SECRET_KEY=<generated-value>
 APP_ALLOWED_HOSTS=vidsense.info,localhost,127.0.0.1
 # ^ Must include the real domain or requests get 400 Bad Request with no body.
 
+# YouTube Data API v3 (required — enable API in Google Cloud, create key)
+YOUTUBE_API_KEY=...
+
 # Set your provider
 LLM_PROVIDER=openai
 OPENAI_API_KEY=sk-...
@@ -223,6 +226,7 @@ sudo -u vidsense /opt/vidsense/.venv/bin/uvicorn main:app --host 127.0.0.1 --por
 The app should start and bind to `127.0.0.1:8000`. If it fails, the most
 common causes are:
 - `APP_SECRET_KEY` still set to the default placeholder
+- Missing or invalid `YOUTUBE_API_KEY` (the app validates it at startup)
 - Missing or wrong `OPENAI_API_KEY` / other provider key
 - Python import error (check `journalctl`)
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,13 +6,14 @@ VidSense is designed to run on a single VM behind a TLS reverse proxy. The [`dep
 
 1. **Set `APP_SECRET_KEY`** in `.env` (the app refuses to start with the default placeholder).  
    Generate one: `python -c "import secrets; print(secrets.token_urlsafe(32))"`
-2. **Set `APP_ALLOWED_HOSTS`** to your public domain plus localhost, e.g. `APP_ALLOWED_HOSTS=vidsense.info,localhost,127.0.0.1`. If this is missing or wrong, requests arriving with the domain `Host` header get a **400 Bad Request** with no body — the most common cause of "blank page after login."
-3. **Set `APP_DEBUG=false`** — disables `/docs`, `/redoc`, `/openapi.json` and hides request bodies from error responses.
-4. **TLS + reverse proxy** — copy [`deploy/Caddyfile`](../deploy/Caddyfile), replace `YOUR_DOMAIN`, and configure `basicauth` credentials. Caddy handles Let's Encrypt automatically.
-5. **Bind address** — the app binds to `127.0.0.1:8000` by default; only the reverse proxy should be internet-facing.
-6. **Firewall** — allow ports **443** (and **80** for ACME). Restrict SSH source IPs, use key-only auth. Do not expose port 8000.
-7. **Non-root service user** — copy [`deploy/vidsense.service`](../deploy/vidsense.service) to `/etc/systemd/system/`, create a `vidsense` user, and adjust paths. See comments in the file.
-8. **File permissions** — `chmod 600 .env`; ensure `data/` is owned by the service user and not world-readable.
+2. **Set `YOUTUBE_API_KEY`** in `.env` — required for YouTube Data API v3 (metadata, tags, comments context); the app refuses to start without it. See [YouTube Data API key](../README.md#youtube-data-api-key) in the README and [`.env.example`](../.env.example).
+3. **Set `APP_ALLOWED_HOSTS`** to your public domain plus localhost, e.g. `APP_ALLOWED_HOSTS=vidsense.info,localhost,127.0.0.1`. If this is missing or wrong, requests arriving with the domain `Host` header get a **400 Bad Request** with no body — the most common cause of "blank page after login."
+4. **Set `APP_DEBUG=false`** — disables `/docs`, `/redoc`, `/openapi.json` and hides request bodies from error responses.
+5. **TLS + reverse proxy** — copy [`deploy/Caddyfile`](../deploy/Caddyfile), replace `YOUR_DOMAIN`, and configure `basicauth` credentials. Caddy handles Let's Encrypt automatically.
+6. **Bind address** — the app binds to `127.0.0.1:8000` by default; only the reverse proxy should be internet-facing.
+7. **Firewall** — allow ports **443** (and **80** for ACME). Restrict SSH source IPs, use key-only auth. Do not expose port 8000.
+8. **Non-root service user** — copy [`deploy/vidsense.service`](../deploy/vidsense.service) to `/etc/systemd/system/`, create a `vidsense` user, and adjust paths. See comments in the file.
+9. **File permissions** — `chmod 600 .env`; ensure `data/` is owned by the service user and not world-readable.
 
 ## Logging
 

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import logging
 from contextlib import asynccontextmanager
 from pathlib import Path
 
+import httpx
 from fastapi import FastAPI, Request, Response
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import HTMLResponse, JSONResponse
@@ -29,6 +30,33 @@ async def lifespan(app: FastAPI):
             "Set a strong random value in your .env file. Generate one with:\n"
             '  python -c "import secrets; print(secrets.token_urlsafe(32))"'
         )
+    if not settings.youtube_api_key:
+        raise RuntimeError(
+            "YOUTUBE_API_KEY is not set. "
+            "Obtain a YouTube Data API v3 key from the Google Cloud Console "
+            "and add it to your .env file."
+        )
+
+    # Validate the YouTube API key with a lightweight request
+    # The special key value "test-yt-api-key-not-real" supports testing without a real key.
+    if settings.youtube_api_key != "test-yt-api-key-not-real":
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.get(
+                    "https://www.googleapis.com/youtube/v3/videos",
+                    params={"id": "dQw4w9WgXcQ", "part": "id", "key": settings.youtube_api_key}
+                )
+                resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code in (400, 403):
+                raise RuntimeError(
+                    f"YOUTUBE_API_KEY is invalid or lacks permissions (HTTP {exc.response.status_code}). "
+                    "Please verify the key and ensure YouTube Data API v3 is enabled in Google Cloud Console."
+                )
+            logger.warning("YouTube API key validation returned HTTP %d, continuing anyway.", exc.response.status_code)
+        except Exception as exc:
+            logger.warning("Could not reach YouTube API to validate key: %s", exc)
+
     await init_db()
     yield
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     "sqlalchemy[asyncio]>=2.0.48",
     "uvicorn[standard]>=0.41.0",
     "youtube-transcript-api>=1.2.4",
-    "yt-dlp>=2026.3.13",
 ]
 
 [dependency-groups]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,9 @@ os.environ["APP_SECRET_KEY"] = (
     "pytest-not-the-production-placeholder-use-only-in-tests"
 )
 
+# Lifespan refuses to start without a YouTube API key; use a dummy for tests.
+os.environ.setdefault("YOUTUBE_API_KEY", "test-yt-api-key-not-real")
+
 # TrustedHostMiddleware: Starlette/FastAPI TestClient defaults to Host: testserver.
 # Developers may set APP_ALLOWED_HOSTS in .env to production-only values; tests still need
 # localhost and testserver while using TestClient.

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -192,9 +192,11 @@ class TestFetchMetadata:
 
     @pytest.mark.asyncio
     async def test_http_error_returns_ingestion_error(self):
+        # 403 = YouTube quota/rate-limit — must be recoverable so the UI
+        # shows a "try again later" affordance instead of a dead end.
         error_resp = httpx.Response(
             status_code=403,
-            json={"error": {"message": "Forbidden"}},
+            json={"error": {"message": "quotaExceeded"}},
             request=httpx.Request("GET", "https://test"),
         )
         with patch("app.services.youtube.httpx.AsyncClient") as mock_client_cls:
@@ -207,6 +209,43 @@ class TestFetchMetadata:
 
         assert isinstance(result, IngestionError)
         assert "403" in result.message
+        assert result.recoverable is True
+
+    @pytest.mark.asyncio
+    async def test_429_returns_recoverable_error(self):
+        error_resp = httpx.Response(
+            status_code=429,
+            json={"error": {"message": "Too Many Requests"}},
+            request=httpx.Request("GET", "https://test"),
+        )
+        with patch("app.services.youtube.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=error_resp)
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _fetch_metadata("any_id")
+
+        assert isinstance(result, IngestionError)
+        assert result.recoverable is True
+
+    @pytest.mark.asyncio
+    async def test_404_is_not_recoverable(self):
+        error_resp = httpx.Response(
+            status_code=404,
+            json={"error": {"message": "Not Found"}},
+            request=httpx.Request("GET", "https://test"),
+        )
+        with patch("app.services.youtube.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=error_resp)
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _fetch_metadata("missing_id")
+
+        assert isinstance(result, IngestionError)
+        assert result.recoverable is False
 
     @pytest.mark.asyncio
     async def test_network_error_returns_recoverable_error(self):

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -1,12 +1,27 @@
 """Tests for the YouTube ingestion service."""
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from youtube_transcript_api import NoTranscriptFound
 
 from app.models.db import TranscriptSourceType
-from app.services.youtube import extract_video_id, _build_raw_text, _detect_language, _fetch_transcript
+from app.models.schemas import IngestionError
+from app.services.youtube import (
+    _build_raw_text,
+    _detect_language,
+    _fetch_metadata,
+    _fetch_top_comments,
+    _parse_iso8601_duration,
+    extract_video_id,
+    _fetch_transcript,
+)
+
+
+# ---------------------------------------------------------------------------
+# URL parsing (unchanged)
+# ---------------------------------------------------------------------------
 
 
 class TestExtractVideoId:
@@ -51,6 +66,48 @@ class TestBuildRawText:
         assert _build_raw_text([]) == ""
 
 
+# ---------------------------------------------------------------------------
+# ISO 8601 duration parser
+# ---------------------------------------------------------------------------
+
+
+class TestParseIso8601Duration:
+    def test_hours_minutes_seconds(self):
+        assert _parse_iso8601_duration("PT1H2M3S") == 3723
+
+    def test_minutes_only(self):
+        assert _parse_iso8601_duration("PT5M") == 300
+
+    def test_seconds_only(self):
+        assert _parse_iso8601_duration("PT30S") == 30
+
+    def test_hours_only(self):
+        assert _parse_iso8601_duration("PT2H") == 7200
+
+    def test_zero_duration(self):
+        assert _parse_iso8601_duration("PT0S") == 0
+
+    def test_days_and_time(self):
+        assert _parse_iso8601_duration("P1DT2H3M4S") == 93784
+
+    def test_p0d(self):
+        assert _parse_iso8601_duration("P0D") == 0
+
+    def test_empty_string(self):
+        assert _parse_iso8601_duration("") is None
+
+    def test_malformed(self):
+        assert _parse_iso8601_duration("not-a-duration") is None
+
+    def test_none_input(self):
+        assert _parse_iso8601_duration(None) is None
+
+
+# ---------------------------------------------------------------------------
+# Language detection (updated for API v3 field names)
+# ---------------------------------------------------------------------------
+
+
 class TestDetectLanguage:
     def test_detects_from_language_field(self):
         assert _detect_language({"language": "en"}) == "en"
@@ -58,12 +115,209 @@ class TestDetectLanguage:
     def test_strips_region_code(self):
         assert _detect_language({"language": "en-US"}) == "en"
 
-    def test_falls_back_to_subtitles(self):
-        info = {"subtitles": {"en": [{"url": "..."}]}}
-        assert _detect_language(info) == "en"
-
     def test_returns_none_when_no_lang(self):
         assert _detect_language({}) is None
+
+    def test_returns_none_for_empty_string(self):
+        assert _detect_language({"language": ""}) is None
+
+
+# ---------------------------------------------------------------------------
+# _fetch_metadata via YouTube Data API v3
+# ---------------------------------------------------------------------------
+
+
+def _make_api_response(items=None, status_code=200):
+    """Build a mock httpx.Response for the videos.list endpoint."""
+    if items is None:
+        items = [
+            {
+                "snippet": {
+                    "title": "Test Video",
+                    "description": "A test description",
+                    "channelTitle": "TestChannel",
+                    "channelId": "UC123",
+                    "publishedAt": "2024-06-15T10:30:00Z",
+                    "thumbnails": {"high": {"url": "https://i.ytimg.com/vi/abc/hq.jpg"}},
+                    "tags": ["python", "tutorial"],
+                    "categoryId": "27",
+                    "defaultAudioLanguage": "en",
+                },
+                "contentDetails": {"duration": "PT12M34S"},
+                "statistics": {"viewCount": "123456", "likeCount": "789"},
+            }
+        ]
+    body = {"items": items}
+    resp = httpx.Response(status_code=status_code, json=body, request=httpx.Request("GET", "https://test"))
+    return resp
+
+
+class TestFetchMetadata:
+    @pytest.mark.asyncio
+    async def test_successful_fetch(self):
+        mock_resp = _make_api_response()
+        with patch("app.services.youtube.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _fetch_metadata("test123")
+
+        assert not isinstance(result, IngestionError)
+        assert result["title"] == "Test Video"
+        assert result["channel"] == "TestChannel"
+        assert result["duration"] == 754  # 12*60 + 34
+        assert result["view_count"] == 123456
+        assert result["like_count"] == 789
+        assert result["tags"] == ["python", "tutorial"]
+        assert result["category"] == "Education"
+        assert result["language"] == "en"
+        assert result["upload_date"] == "2024-06-15T10:30:00Z"
+        assert "channel/UC123" in result["channel_url"]
+
+    @pytest.mark.asyncio
+    async def test_empty_items_returns_error(self):
+        mock_resp = _make_api_response(items=[])
+        with patch("app.services.youtube.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _fetch_metadata("nonexistent")
+
+        assert isinstance(result, IngestionError)
+        assert result.error_code == "METADATA_FETCH_FAILED"
+
+    @pytest.mark.asyncio
+    async def test_http_error_returns_ingestion_error(self):
+        error_resp = httpx.Response(
+            status_code=403,
+            json={"error": {"message": "Forbidden"}},
+            request=httpx.Request("GET", "https://test"),
+        )
+        with patch("app.services.youtube.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=error_resp)
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _fetch_metadata("forbidden_id")
+
+        assert isinstance(result, IngestionError)
+        assert "403" in result.message
+
+    @pytest.mark.asyncio
+    async def test_network_error_returns_recoverable_error(self):
+        with patch("app.services.youtube.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(side_effect=httpx.ConnectError("Network down"))
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _fetch_metadata("any_id")
+
+        assert isinstance(result, IngestionError)
+        assert result.recoverable is True
+
+
+# ---------------------------------------------------------------------------
+# _fetch_top_comments
+# ---------------------------------------------------------------------------
+
+
+class TestFetchTopComments:
+    @pytest.mark.asyncio
+    async def test_successful_fetch(self):
+        body = {
+            "items": [
+                {
+                    "snippet": {
+                        "topLevelComment": {
+                            "snippet": {
+                                "authorDisplayName": "Alice",
+                                "textDisplay": "Great video!",
+                            }
+                        }
+                    }
+                },
+                {
+                    "snippet": {
+                        "topLevelComment": {
+                            "snippet": {
+                                "authorDisplayName": "Bob",
+                                "textDisplay": "Very informative.",
+                            }
+                        }
+                    }
+                },
+            ]
+        }
+        mock_resp = httpx.Response(200, json=body, request=httpx.Request("GET", "https://test"))
+        with patch("app.services.youtube.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _fetch_top_comments("test123")
+
+        assert result is not None
+        assert len(result) == 2
+        assert result[0]["author"] == "Alice"
+        assert result[0]["text"] == "Great video!"
+
+    @pytest.mark.asyncio
+    async def test_comments_disabled_returns_none(self):
+        error_resp = httpx.Response(
+            status_code=403,
+            json={"error": {"errors": [{"reason": "commentsDisabled"}]}},
+            request=httpx.Request("GET", "https://test"),
+        )
+        with patch("app.services.youtube.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=error_resp)
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _fetch_top_comments("no_comments")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_truncates_long_comments(self):
+        long_text = "x" * 500
+        body = {
+            "items": [
+                {
+                    "snippet": {
+                        "topLevelComment": {
+                            "snippet": {
+                                "authorDisplayName": "Verbose",
+                                "textDisplay": long_text,
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+        mock_resp = httpx.Response(200, json=body, request=httpx.Request("GET", "https://test"))
+        with patch("app.services.youtube.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _fetch_top_comments("test123")
+
+        assert result is not None
+        assert len(result[0]["text"]) == 300
+
+
+# ---------------------------------------------------------------------------
+# Transcript (unchanged — youtube-transcript-api stays)
+# ---------------------------------------------------------------------------
 
 
 def _make_transcript(language_code: str, is_generated: bool, texts: list[str] | None = None):

--- a/uv.lock
+++ b/uv.lock
@@ -2111,7 +2111,6 @@ dependencies = [
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "uvicorn", extra = ["standard"] },
     { name = "youtube-transcript-api" },
-    { name = "yt-dlp" },
 ]
 
 [package.dev-dependencies]
@@ -2140,7 +2139,6 @@ requires-dist = [
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.48" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.41.0" },
     { name = "youtube-transcript-api", specifier = ">=1.2.4" },
-    { name = "yt-dlp", specifier = ">=2026.3.13" },
 ]
 
 [package.metadata.requires-dev]
@@ -2462,15 +2460,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/60/43/4104185a2eaa839daa693b30e15c37e7e58795e8e09ec414f22b3db54bec/youtube_transcript_api-1.2.4.tar.gz", hash = "sha256:b72d0e96a335df599d67cee51d49e143cff4f45b84bcafc202ff51291603ddcd", size = 469839, upload-time = "2026-01-29T09:09:17.088Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/95/129ea37efd6cd6ed00f62baae6543345c677810b8a3bf0026756e1d3cf3c/youtube_transcript_api-1.2.4-py3-none-any.whl", hash = "sha256:03878759356da5caf5edac77431780b91448fb3d8c21d4496015bdc8a7bc43ff", size = 485227, upload-time = "2026-01-29T09:09:15.427Z" },
-]
-
-[[package]]
-name = "yt-dlp"
-version = "2026.3.13"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/34/69/59253e5627f583939e742a592f56dc7d7f30d164473e58f055e1fccdc02b/yt_dlp-2026.3.13.tar.gz", hash = "sha256:fb43659db684a3db6ff2f5c92e0f1641262f6ecc71dbb64fefe84177aaba9e36", size = 3117911, upload-time = "2026-03-13T09:02:22.711Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/ef/52ed7ed10d2e1a22badf74b520b617c48b0a725a981620393245ac842bf9/yt_dlp-2026.3.13-py3-none-any.whl", hash = "sha256:e22e7716f94c08e76b29c0172a3fe0c01d8cabab9bce7f528ad440d70a0d213c", size = 3315062, upload-time = "2026-03-13T09:02:20.357Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches ingestion, DB schema, and pipeline prompting; failures or quota/key issues can block startup or change stored video metadata. Risk is moderated by best-effort comments handling and expanded test coverage around API error cases.
> 
> **Overview**
> Replaces `yt-dlp` metadata scraping with YouTube Data API v3 calls (`httpx` async) for video metadata, adds best-effort top-comment fetching, and stores creator tags/comments/category on the `Video` record for downstream use.
> 
> Introduces required YouTube settings (`YOUTUBE_API_KEY`, comment limits) with startup validation, adds DB columns (`tags_json`, `top_comments_json`, `category`), updates the UI to display ISO-8601 `upload_date` alongside legacy `YYYYMMDD`, and injects the new video context into summary/chapter LLM prompts by passing `Video` data through the pipeline state.
> 
> Removes the `yt-dlp` dependency/lock entries and rewrites YouTube ingestion tests to mock `httpx`, including ISO-8601 duration parsing and comment fetching behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f840a86012f9f13955f3ab1c942e596a7519aa77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->