### PR TITLE
ci: GitHub Actions for lint + tests (PR 2/4 for #25)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_call: {}
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --group dev --frozen
+
+      - name: Ruff lint
+        run: uv run ruff check .
+
+      - name: Ruff format check
+        run: uv run ruff format --check .
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --group dev --frozen
+
+      - name: Run pytest
+        run: uv run pytest -q


### PR DESCRIPTION
Second PR of four for #25. Adds the actual CI workflow. The Ruff baseline from #26 landed in main, so this PR's own CI run should be the first clean green signal.

## What this does

Adds [.github/workflows/ci.yml](.github/workflows/ci.yml) with two jobs:

- **lint**: `uv run ruff check .` + `uv run ruff format --check .`
- **test**: `uv run pytest -q`

Both jobs:

- Trigger on `pull_request` to `main`, `push` to `main`, and `workflow_call` (so the later `deploy.yml` can reuse it and we never deploy a red build).
- Use `astral-sh/setup-uv@v5` with cache keyed on `uv.lock`.
- Install deps with `uv sync --group dev --frozen` - lockfile is authoritative; any drift between `pyproject.toml` and `uv.lock` fails CI. Intentional.
- `concurrency` group cancels superseded PR runs when a new commit arrives.

No secrets needed. [tests/conftest.py](tests/conftest.py) already stubs `APP_SECRET_KEY`, `YOUTUBE_API_KEY`, and `APP_ALLOWED_HOSTS` before app modules import, so the suite runs cleanly on a fresh runner.

## Verification

Local, on this branch:

- `uv run ruff check .` -> All checks passed
- `uv run ruff format --check .` -> 32 files already formatted
- `uv run pytest -q` -> 206 passed in 16.71s

## What to do after merging

Enable branch protection on `main`:

1. Settings -> Branches -> Add rule for `main`.
2. Check **Require a pull request before merging**.
3. Check **Require status checks to pass before merging** and select `lint` and `test` (these names will only appear in the dropdown *after* this PR's CI has reported once).
4. Check **Require branches to be up to date before merging**.

Once protection is on, any future rename of the `lint` or `test` job in this workflow silently stops enforcing it, so coordinate renames with a Settings -> Branches update.

## Not in this PR

- Deploy scaffolding (PR 3: `greg/25-deploy-scaffold`).
- Deploy workflow (PR 4: `greg/25-deploy-workflow`).
- mypy, Dependabot, CODEOWNERS (optional follow-ups).

Refs #25

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change; primary risk is CI false failures or longer build times due to dependency sync/lockfile enforcement.
> 
> **Overview**
> Introduces a new GitHub Actions workflow `ci.yml` that runs on PRs and pushes to `main` (and via `workflow_call`) with concurrency cancellation for superseded runs.
> 
> The workflow adds two jobs: **lint** (Ruff `check` + `format --check`) and **test** (`pytest`), installing dependencies via `uv sync --group dev --frozen` with `uv.lock`-keyed caching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe4884144e5bf7a01ce11cf522888dde4f2830f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->