### PR TITLE
deploy: scaffold update.sh and VM prerequisites (PR 3/4 for #25)

### DIFF
--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -118,11 +118,20 @@ systemctl enable --now caddy
 # ---------------------------------------------------------------------------
 # 4. Service user
 # ---------------------------------------------------------------------------
+# Shell is /bin/bash so the GitHub Actions deploy workflow can SSH in as this
+# user and run deploy/update.sh. The SSH key added to authorized_keys should
+# be restricted (e.g. command=".../deploy/update.sh") to limit what it can do.
 if ! id "${SERVICE_USER}" &>/dev/null; then
-    info "Creating system user '${SERVICE_USER}'..."
-    useradd --system --shell /usr/sbin/nologin --home-dir "${DEPLOY_DIR}" "${SERVICE_USER}"
+    info "Creating system user '${SERVICE_USER}' with /bin/bash shell..."
+    useradd --system --shell /bin/bash --home-dir "${DEPLOY_DIR}" "${SERVICE_USER}"
 else
-    info "User '${SERVICE_USER}' already exists, skipping."
+    current_shell=$(getent passwd "${SERVICE_USER}" | cut -d: -f7)
+    if [[ "${current_shell}" != "/bin/bash" ]]; then
+        info "Updating '${SERVICE_USER}' shell from ${current_shell} to /bin/bash for SSH-based deploys..."
+        usermod --shell /bin/bash "${SERVICE_USER}"
+    else
+        info "User '${SERVICE_USER}' already exists with /bin/bash shell, skipping."
+    fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -176,6 +185,30 @@ info "Installing systemd unit..."
 cp "${DEPLOY_DIR}/deploy/vidsense.service" /etc/systemd/system/vidsense.service
 systemctl daemon-reload
 systemctl enable vidsense
+
+# ---------------------------------------------------------------------------
+# 9. Sudoers rule for CI-driven deploys
+# ---------------------------------------------------------------------------
+# The GitHub Actions deploy workflow SSHes in as the vidsense user and runs
+# deploy/update.sh, which needs to restart this systemd unit. Grant exactly
+# that one command — nothing else — so the deploy key has least privilege.
+# Generated file is validated with visudo before installing, so a malformed
+# rule cannot break sudo on the host.
+info "Installing sudoers rule at /etc/sudoers.d/vidsense for CI deploys..."
+SUDOERS_FILE="/etc/sudoers.d/vidsense"
+SUDOERS_TMP="$(mktemp)"
+cat > "${SUDOERS_TMP}" <<EOF
+${SERVICE_USER} ALL=(root) NOPASSWD: /bin/systemctl restart vidsense
+EOF
+if visudo -cf "${SUDOERS_TMP}" >/dev/null; then
+    install -m 0440 -o root -g root "${SUDOERS_TMP}" "${SUDOERS_FILE}"
+    info "Installed ${SUDOERS_FILE}."
+else
+    rm -f "${SUDOERS_TMP}"
+    echo "[bootstrap] ERROR: generated sudoers file failed validation; not installed." >&2
+    exit 1
+fi
+rm -f "${SUDOERS_TMP}"
 
 # ---------------------------------------------------------------------------
 # Done

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -96,6 +96,9 @@ if (( consecutive < REQUIRED_SUCCESSES )); then
 fi
 
 log "${SERVICE_NAME} is serving (HTTP ${last_status})."
-systemctl status "${SERVICE_NAME}" --no-pager | head -n 20
+# `|| true` guards against SIGPIPE (exit 141) when `head` closes its stdin
+# before `systemctl status` finishes writing — under `set -euo pipefail`
+# that would abort an otherwise-successful deploy.
+systemctl status "${SERVICE_NAME}" --no-pager | head -n 20 || true
 
 log "Deploy of ${BRANCH} complete at $(git rev-parse --short HEAD)."

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# VidSense — on-VM deploy script.
+#
+# Invoked by the GitHub Actions deploy workflow via SSH as the `vidsense`
+# service user:
+#
+#     ssh vidsense@<host> bash /opt/vidsense/deploy/update.sh [branch]
+#
+# The script is safe to re-run. It fails loudly if any step breaks so
+# partial deploys show up as red builds instead of silent drift.
+#
+# Prerequisites (installed by deploy/bootstrap.sh):
+#   - /opt/vidsense is a git checkout of the project.
+#   - The vidsense service user has /bin/bash as its login shell.
+#   - /etc/sudoers.d/vidsense grants:
+#       vidsense ALL=(root) NOPASSWD: /bin/systemctl restart vidsense
+#   - uv is on PATH at /usr/local/bin/uv.
+
+set -euo pipefail
+
+# Explicit environment: SSH non-interactive sessions inherit a minimal env,
+# and uv needs HOME/XDG pointed at the service user's directory so caches
+# and configs land where bootstrap.sh expects them.
+export PATH="/usr/local/bin:/usr/bin:/bin"
+export HOME="/opt/vidsense"
+export XDG_CONFIG_HOME="${HOME}/.config"
+export XDG_CACHE_HOME="${HOME}/.cache"
+
+DEPLOY_DIR="/opt/vidsense"
+SERVICE_NAME="vidsense"
+BRANCH="${1:-main}"
+
+log() { echo "[update] $*"; }
+
+if [[ ! -d "${DEPLOY_DIR}/.git" ]]; then
+    echo "[update] ERROR: ${DEPLOY_DIR} is not a git checkout." >&2
+    exit 1
+fi
+
+cd "${DEPLOY_DIR}"
+
+log "Fetching origin..."
+git fetch --prune origin
+
+log "Checking out ${BRANCH}..."
+git checkout "${BRANCH}"
+git pull --ff-only origin "${BRANCH}"
+
+log "Syncing dependencies (uv sync --frozen)..."
+uv sync --frozen
+
+log "Restarting ${SERVICE_NAME}..."
+sudo /bin/systemctl restart "${SERVICE_NAME}"
+
+# systemctl restart blocks until the unit reaches an active state or fails,
+# but double-check explicitly so a subtle unit failure can't be confused
+# with a successful deploy.
+if ! systemctl is-active --quiet "${SERVICE_NAME}"; then
+    echo "[update] ERROR: ${SERVICE_NAME} is not active after restart." >&2
+    systemctl status "${SERVICE_NAME}" --no-pager | head -n 40 >&2 || true
+    exit 1
+fi
+
+systemctl status "${SERVICE_NAME}" --no-pager | head -n 20
+
+log "Deploy of ${BRANCH} complete at $(git rev-parse --short HEAD)."

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -72,7 +72,12 @@ deadline=$(( $(date +%s) + HEALTH_TIMEOUT ))
 consecutive=0
 last_status="000"
 while (( $(date +%s) < deadline )); do
-    last_status=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 2 "${HEALTH_URL}" || echo "000")
+    # curl writes "%{http_code}" (e.g. "000" on connect failure, "200" on a
+    # successful header exchange that then times out on the body) to stdout
+    # *before* exiting non-zero. Using `|| true` preserves that value;
+    # `|| echo "000"` would append and give us e.g. "000000" or "200000",
+    # which fails the regex below and causes false-negative health checks.
+    last_status=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 2 "${HEALTH_URL}" || true)
     if [[ "${last_status}" =~ ^[1-5][0-9][0-9]$ ]]; then
         consecutive=$(( consecutive + 1 ))
         if (( consecutive >= REQUIRED_SUCCESSES )); then

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -52,15 +52,45 @@ uv sync --frozen
 log "Restarting ${SERVICE_NAME}..."
 sudo /bin/systemctl restart "${SERVICE_NAME}"
 
-# systemctl restart blocks until the unit reaches an active state or fails,
-# but double-check explicitly so a subtle unit failure can't be confused
-# with a successful deploy.
-if ! systemctl is-active --quiet "${SERVICE_NAME}"; then
-    echo "[update] ERROR: ${SERVICE_NAME} is not active after restart." >&2
+# vidsense.service is Type=simple, so `systemctl restart` returns as soon as
+# the uvicorn process is forked — long before it has imported main:app, run
+# its lifespan hook, or bound :8000. That makes `is-active` a near-no-op for
+# the most common deploy-time failures (import errors, missing APP_SECRET_KEY,
+# invalid YOUTUBE_API_KEY, etc.), because Restart=on-failure keeps the unit
+# flipping between "activating" and "active" during a crash loop.
+#
+# The real readiness signal is an HTTP response on the listen port: any status
+# code from 100–599 proves uvicorn imported the app and bound the socket.
+# Require several consecutive successes so a service that briefly answers
+# before crashing can't masquerade as healthy.
+HEALTH_URL="http://127.0.0.1:8000/"
+HEALTH_TIMEOUT=30
+REQUIRED_SUCCESSES=3
+
+log "Probing ${HEALTH_URL} for ${REQUIRED_SUCCESSES} consecutive successes (timeout ${HEALTH_TIMEOUT}s)..."
+deadline=$(( $(date +%s) + HEALTH_TIMEOUT ))
+consecutive=0
+last_status="000"
+while (( $(date +%s) < deadline )); do
+    last_status=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 2 "${HEALTH_URL}" || echo "000")
+    if [[ "${last_status}" =~ ^[1-5][0-9][0-9]$ ]]; then
+        consecutive=$(( consecutive + 1 ))
+        if (( consecutive >= REQUIRED_SUCCESSES )); then
+            break
+        fi
+    else
+        consecutive=0
+    fi
+    sleep 1
+done
+
+if (( consecutive < REQUIRED_SUCCESSES )); then
+    echo "[update] ERROR: ${SERVICE_NAME} did not stay healthy on ${HEALTH_URL} within ${HEALTH_TIMEOUT}s (last HTTP status: ${last_status})." >&2
     systemctl status "${SERVICE_NAME}" --no-pager | head -n 40 >&2 || true
     exit 1
 fi
 
+log "${SERVICE_NAME} is serving (HTTP ${last_status})."
 systemctl status "${SERVICE_NAME}" --no-pager | head -n 20
 
 log "Deploy of ${BRANCH} complete at $(git rev-parse --short HEAD)."


### PR DESCRIPTION
Third PR of four for #25. Adds the on-VM pieces the deploy workflow will rely on. No workflow yet — that's PR 4.

## What this does

### New: [deploy/update.sh](deploy/update.sh) (0755)

On-VM deploy entry point. Invoked by the GitHub Actions deploy workflow via SSH:

\`\`\`
ssh vidsense@<host> bash /opt/vidsense/deploy/update.sh [branch]
\`\`\`

Steps:

1. Export explicit \`PATH\` / \`HOME\` / \`XDG_*\` (SSH non-interactive sessions inherit a minimal env; uv needs these pointed at the service user's directory).
2. \`git fetch --prune origin\`, \`git checkout <branch>\`, \`git pull --ff-only\`.
3. \`uv sync --frozen\` (matches CI semantics).
4. \`sudo /bin/systemctl restart vidsense\`.
5. **Verify explicitly** with \`systemctl is-active --quiet\`; if not active, dump status to stderr and exit non-zero. This turns partial deploys (new code on disk, old process still running) into red builds instead of silent drift (risk #4 in the plan).
6. Print short status and the deployed commit SHA.

### Updated: [deploy/bootstrap.sh](deploy/bootstrap.sh)

Two changes, both idempotent:

- **Section 4 (service user)**: shell changed from \`/usr/sbin/nologin\` to \`/bin/bash\` so the deploy workflow can SSH in as \`vidsense\`. For existing installs, \`usermod --shell /bin/bash\` updates in place. The comment calls out that least-privilege should come from restricting the SSH key in \`authorized_keys\` (\`command="..."\`), not from the shell.
- **New section 9 (sudoers)**: installs \`/etc/sudoers.d/vidsense\` containing exactly one rule:

  \`\`\`
  vidsense ALL=(root) NOPASSWD: /bin/systemctl restart vidsense
  \`\`\`

  Only \`restart\` needs root. \`status\` / \`is-active\` run unprivileged. The file is validated with \`visudo -cf\` before install, so a malformed rule cannot break \`sudo\` on the host.

## Verification

- \`bash -n deploy/update.sh\` / \`bash -n deploy/bootstrap.sh\` — both parse clean.
- \`uv run ruff check .\` / \`ruff format --check .\` — unchanged, still green.
- \`pytest\` on \`main\`'s CI run was green; these files aren't covered by tests (they run on a Linux VM), so CI here validates the workflow infra only.

## What this does NOT do

- No \`.github/workflows/deploy.yml\` (that's PR 4).
- No changes to any application code, no runtime behavior change.
- No VM is touched by this PR. The bootstrap.sh changes apply the next time \`bootstrap.sh\` is run on a host (or on a fresh host).

## Post-merge manual step

On each dev/prod VM (only dev for now per the plan):

\`\`\`bash
sudo bash /opt/vidsense/deploy/bootstrap.sh
\`\`\`

This is idempotent. After it runs, the VM is CI-deploy-ready: \`vidsense\` has a login shell and the sudoers rule is in place. Still required in PR 4: adding the deploy public key to \`~vidsense/.ssh/authorized_keys\` and setting the GitHub environment secrets.

Refs #25

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces SSH-capable service user configuration and a new sudoers rule, which can impact host security if misconfigured, though the rule is narrowly scoped and validated with `visudo`.
> 
> **Overview**
> Adds an on-VM deploy entrypoint `deploy/update.sh` for CI-driven SSH deploys: it fast-forwards a target branch, runs `uv sync --frozen`, restarts the `vidsense` systemd unit, and fails the deploy unless the app returns successful HTTP responses on `127.0.0.1:8000` within a timeout.
> 
> Updates `deploy/bootstrap.sh` to make the `vidsense` service user SSH-capable by ensuring its login shell is `/bin/bash`, and installs a validated least-privilege sudoers rule allowing only `NOPASSWD: /bin/systemctl restart vidsense` for that user.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0faf9faf7befff08e900642b5489eda2d36e514b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->