### PR TITLE
ci: auto-deploy main to dev and surface journal on deploy failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,14 @@
 name: Deploy
 
-# Manual dispatch only for now. Once the first dev deploy has been verified
-# end-to-end, a small follow-up PR will add `on: push: branches: [main]` here
-# to auto-deploy merged PRs to dev.
+# Triggers:
+#   - push to main: auto-deploy merged PRs to dev (the `ci` job below re-runs
+#     lint+tests on the merge commit as a last-mile gate before SSHing to the
+#     VM, since PR CI ran on the PR head, not on post-merge main).
+#   - workflow_dispatch: manual redeploy / ad-hoc branch deploy to dev. Useful
+#     for redeploying after a VM config change without forcing an empty commit.
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       environment:

--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -134,6 +134,18 @@ else
     fi
 fi
 
+# Grant read access to the system journal so deploy/update.sh (invoked via SSH
+# by the GitHub Actions deploy workflow) can dump recent unit logs on a failed
+# health probe without needing sudo. Without this membership, non-root users on
+# Ubuntu can only read their own user-scoped journals, so `journalctl -u
+# vidsense` prints nothing useful from the CI log.
+if id -nG "${SERVICE_USER}" | tr ' ' '\n' | grep -qx systemd-journal; then
+    info "User '${SERVICE_USER}' is already in systemd-journal group, skipping."
+else
+    info "Adding '${SERVICE_USER}' to systemd-journal group for diagnostic journalctl access..."
+    usermod -aG systemd-journal "${SERVICE_USER}"
+fi
+
 # ---------------------------------------------------------------------------
 # 5. Clone or update the repository
 # ---------------------------------------------------------------------------

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -91,7 +91,14 @@ done
 
 if (( consecutive < REQUIRED_SUCCESSES )); then
     echo "[update] ERROR: ${SERVICE_NAME} did not stay healthy on ${HEALTH_URL} within ${HEALTH_TIMEOUT}s (last HTTP status: ${last_status})." >&2
+    # `systemctl status` shows the current unit state (e.g. "active (running)"
+    # during a crash loop where Restart=on-failure keeps respawning uvicorn).
+    # That's nearly useless for diagnosis — the actual Python traceback is in
+    # the journal. Dump both so the GitHub Actions log surfaces the root cause
+    # without requiring an SSH round-trip.
     systemctl status "${SERVICE_NAME}" --no-pager | head -n 40 >&2 || true
+    echo "[update] Last ${SERVICE_NAME} journal lines:" >&2
+    journalctl -u "${SERVICE_NAME}" -n 80 --no-pager >&2 || true
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
Three small follow-ups to the dev deploy pipeline, motivated by the first green manual deploy of PR #30:

- **`.github/workflows/deploy.yml`** — add `on: push: branches: [main]` so merged PRs auto-deploy to dev. Manual `workflow_dispatch` is kept for redeploys and ad-hoc branch deploys. The existing `ci` reusable job re-runs on the post-merge commit as a last-mile gate before SSH.
- **`deploy/update.sh`** — dump the last 80 `vidsense.service` journal lines to the Actions log when the HTTP health probe fails. Without this, a crash-looping unit shows as `active (running)` in `systemctl status` (because `Restart=on-failure` keeps respawning uvicorn), so deploy-time Python errors are invisible until you SSH to the VM. The missing-`YOUTUBE_API_KEY` failure from the first deploy attempt would have shown up directly in the Actions log with this in place.
- **`deploy/bootstrap.sh`** — add the `vidsense` service user to the `systemd-journal` group so the new `journalctl` dump can read `/var/log/journal` without sudo. Safe to re-run (membership check guards it). **Requires re-running `bootstrap.sh` on the dev VM once before the journal dump lights up.** Until then, the dump step fails silently (`|| true`) and behavior matches today.

## Test plan
- [ ] Merge PR; confirm push-to-main triggers a Deploy run targeting the `dev` environment.
- [ ] Confirm the `ci` job runs first, then `deploy`, and the VM ends up at the merge commit (compare `git rev-parse --short HEAD` in the Actions log to the merge SHA).
- [ ] On the dev VM, re-run bootstrap once to pick up the `systemd-journal` group change:
      `cd /opt/vidsense && sudo -u vidsense git pull --ff-only origin main && sudo bash deploy/bootstrap.sh`
- [ ] Verify the new group membership: `id vidsense | tr ',' '\n' | grep systemd-journal`
- [ ] Force a deliberate deploy failure (e.g. temporarily rename `APP_SECRET_KEY` in `/opt/vidsense/.env` and dispatch the workflow) and confirm the Actions log now shows the Python traceback from `journalctl -u vidsense` — then restore `.env` and redeploy to green.
- [ ] Sanity-check manual `workflow_dispatch` still works (redeploy `main` explicitly).

Refs #25

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CI/CD trigger to auto-deploy on `main` pushes and modifies VM bootstrap permissions/group membership, which can impact deployment behavior and access if misconfigured.
> 
> **Overview**
> The deploy workflow now triggers on **pushes to `main`** (in addition to manual `workflow_dispatch`), so merged PRs auto-deploy to the dev VM after re-running the reusable `ci` gate on the merge commit.
> 
> Deploy diagnostics are improved: `deploy/update.sh` prints recent `journalctl -u vidsense` output when the post-restart HTTP health probe fails, and `deploy/bootstrap.sh` adds the service user to the `systemd-journal` group so those journal reads work over SSH without sudo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8559c1b333c9aed42dc29192a5944e43536eaa75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->