### PR TITLE
feat: fix youtube ip block on cloud vm

### DIFF
--- a/.cursor/plans/fix_youtube_ip_block_on_vm_3ebe5546.plan.md
+++ b/.cursor/plans/fix_youtube_ip_block_on_vm_3ebe5546.plan.md
@@ -1,0 +1,302 @@
+---
+name: Fix YouTube IP block on VM
+overview: Introduce a small pluggable transcript-provider layer behind `_fetch_transcript`, ship a Webshare residential-proxy provider as the recommended production fix for cloud-VM IP bans, keep the current direct-fetch path as the zero-config default for local dev, and offload the (still-synchronous) transcript fetch off the asyncio event loop via `asyncio.to_thread` (folds in GitHub issue
+todos:
+  - id: config
+    content: Add webshare_proxy_username and webshare_proxy_password fields to Settings plus a webshare_proxy_enabled computed property; add a model_validator that rejects the half-configured state (exactly one of the two set)
+    status: completed
+  - id: provider-seam
+    content: Introduce _build_transcript_api() in app/services/youtube.py and route _fetch_transcript through it
+    status: completed
+  - id: async-offload
+    content: Offload the synchronous _fetch_transcript to a worker thread via asyncio.to_thread in ingest_video so proxy hops and per-request retries (WebshareProxyConfig default retries_when_blocked=10) don't block the event loop (folds in GitHub issue
+    status: completed
+  - id: error-mapping
+    content: Catch RequestBlocked / IpBlocked from youtube_transcript_api and map them to new TRANSCRIPT_IP_BLOCKED IngestionError code
+    status: completed
+  - id: error-ui
+    content: Add TRANSCRIPT_IP_BLOCKED entry to app/templates/partials/error.html so the error surfaces with the right title/hint/icon instead of the generic fallback
+    status: completed
+  - id: tests
+    content: Add unit tests for provider selection (webshare_proxy_enabled true vs false), the half-configured validator error, IP-block error mapping, and the asyncio.to_thread offload path in tests/test_youtube.py
+    status: completed
+  - id: docs
+    content: Document the VM transcript-proxy setup in docs/deployment.md and .env.example
+    status: completed
+isProject: false
+---
+
+# Fix YouTube IP Block on Cloud VM
+
+## Root cause recap
+
+Two YouTube surfaces are in use in [app/services/youtube.py](app/services/youtube.py):
+
+- `googleapis.com/youtube/v3` (authenticated, API key) — works fine from any IP.
+- `youtube.com` innertube via `YouTubeTranscriptApi` (unauthenticated) — YouTube blocks entire cloud-datacenter IP ranges. This is what fails on your VM. The same block will hit prod.
+
+Subsystem health is narrow: the metadata, comments, caching, and language-ranking subsystems are not themselves broken and need no changes. But end-to-end ingestion is not "mostly working" — `ingest_video` in [app/services/youtube.py](app/services/youtube.py) treats transcript retrieval as a hard required step, so on a blocked VM the whole ingestion pipeline fails. Fixing the transcript egress path restores end-to-end ingestion.
+
+## Approach
+
+Add a thin **transcript-api builder** seam inside `app/services/youtube.py` and derive behavior purely from whether Webshare credentials are configured:
+
+- **Direct path** (default, current behavior, no creds set) — `YouTubeTranscriptApi()` with no proxy. Keeps local dev zero-config.
+- **Webshare path** (both `WEBSHARE_PROXY_USERNAME` and `WEBSHARE_PROXY_PASSWORD` set) — `YouTubeTranscriptApi(proxy_config=WebshareProxyConfig(...))`. This is the library's officially supported proxy integration.
+
+There is intentionally **no explicit provider flag** in this plan. A generic `http_proxy` or ASR option is trivial to add later (one extra class + one extra boolean), and that is the right moment to introduce an explicit flag — not now.
+
+```mermaid
+flowchart LR
+    caller["ingest_video()"] --> ft["_fetch_transcript(video_id)"]
+    ft --> build["_build_transcript_api()"]
+    build -->|"webshare_proxy_enabled"| ws["YouTubeTranscriptApi\n+ WebshareProxyConfig"]
+    build -->|"otherwise"| dir["YouTubeTranscriptApi()\n(no proxy)"]
+    ws --> yt["youtube.com"]
+    dir --> yt
+```
+
+The existing 4-tier language ranking and error-to-`IngestionError` mapping stay inside `_fetch_transcript`; only the call that produces `transcript_list` moves behind the provider.
+
+## Changes
+
+### 1. Dependency — no new package needed
+
+`youtube-transcript-api>=1.2.4` already bundles `WebshareProxyConfig` and `GenericProxyConfig`. Verified in [pyproject.toml](pyproject.toml). No additions.
+
+### 2. Config — two new optional env vars
+
+The contract is deliberately simple: **the provider is `webshare` if and only if both Webshare credentials are set; otherwise it's `direct`.** No separate flag, no auto-upgrade, no three-way validation. This matches the project's stated "simpler contract" preference and can still evolve later (e.g., when a third provider is added, that is the right time to introduce an explicit flag).
+
+In [app/config.py](app/config.py), add to `Settings`:
+
+```python
+webshare_proxy_username: str = Field(default="", description="Webshare proxy username. If set together with webshare_proxy_password, transcript fetches route through Webshare residential proxies.")
+webshare_proxy_password: str = Field(default="", description="Webshare proxy password. See webshare_proxy_username.")
+```
+
+And a computed property:
+
+```python
+@computed_field
+@property
+def webshare_proxy_enabled(self) -> bool:
+    return bool(self.webshare_proxy_username and self.webshare_proxy_password)
+```
+
+Add one `model_validator(mode="after")` check: if **exactly one** of the two Webshare vars is set, raise a clear startup error. This follows the same fail-fast principle as the existing startup guards in [main.py](main.py) for `APP_SECRET_KEY` and `YOUTUBE_API_KEY`, but it happens even earlier at settings-load time. Both set or neither set are the only valid states. This catches the most common misconfiguration (operator pastes the username but forgets the password, or vice versa) immediately at boot instead of silently falling back to `direct` and hitting the IP-block at request time.
+
+No other new env vars. `domain_name`, `proxy_port`, `filter_ip_locations`, `retries_when_blocked` are intentionally not exposed — `WebshareProxyConfig` defaults are correct for this use case, and exposing them now would add surface area without adding value. Documented as "knobs that exist but are not wired" in the deployment doc.
+
+### 3. Provider seam in [app/services/youtube.py](app/services/youtube.py)
+
+Add (near the top of the transcript section):
+
+```python
+from youtube_transcript_api.proxies import WebshareProxyConfig
+
+def _build_transcript_api() -> YouTubeTranscriptApi:
+    """Return a YouTubeTranscriptApi, routed through Webshare if credentials are configured."""
+    if settings.webshare_proxy_enabled:
+        return YouTubeTranscriptApi(
+            proxy_config=WebshareProxyConfig(
+                proxy_username=settings.webshare_proxy_username,
+                proxy_password=settings.webshare_proxy_password,
+            )
+        )
+    return YouTubeTranscriptApi()
+```
+
+In `_fetch_transcript`, replace the single line:
+
+```python
+transcript_list = YouTubeTranscriptApi().list(video_id)
+```
+
+with:
+
+```python
+transcript_list = _build_transcript_api().list(video_id)
+```
+
+The 4-tier ranking and `_to_segments` logic are unchanged. The surrounding `try`/`except` structure is restructured as described in Section 5 so typed IP-block exceptions from any network phase (including `transcript.fetch()`) are mapped consistently.
+
+### 4. Async offload — stop blocking the event loop (GitHub issue #24)
+
+`youtube-transcript-api` is a synchronous library built on `requests`. Today `_fetch_transcript` is a plain `def` and is called directly from the async `ingest_video`, so every transcript fetch blocks the FastAPI event loop for its entire duration. That is already a bottleneck on the direct path; it becomes materially worse after this plan lands because:
+
+- Webshare adds a proxy hop (extra network RTT) per request.
+- `WebshareProxyConfig.retries_when_blocked` defaults to **10** — a single blocked fetch can now hold the event loop for tens of seconds while the library retries internally.
+- `_to_segments` inside `_fetch_transcript` calls `transcript.fetch()`, which is another blocking HTTP call per transcript. Offloading the whole `_fetch_transcript` covers it for free.
+
+Fix: keep `_fetch_transcript` synchronous (the library is sync, and keeping it sync keeps the existing tests unchanged), and wrap only at the async call site in `ingest_video`.
+
+Add the import at the top of [app/services/youtube.py](app/services/youtube.py):
+
+```python
+import asyncio
+```
+
+Change the call site in `ingest_video` from:
+
+```python
+transcript_result = _fetch_transcript(video_id)
+```
+
+to:
+
+```python
+transcript_result = await asyncio.to_thread(_fetch_transcript, video_id)
+```
+
+That is the entire code change for the offload. No interface change, no provider-protocol churn, and no existing test needs to be rewritten — new tests are additive, per Section 7. Providers stay sync because the underlying library is sync — if a future natively-async provider (e.g., an HTTP-based third-party vendor) is added later, it can expose its own async entry point and the caller picks the right one.
+
+Once this ships, close GitHub issue #24 with a reference to the commit.
+
+### 5. Error taxonomy — make IP-block failures actionable
+
+`youtube_transcript_api` exports `RequestBlocked` and `IpBlocked` as public typed exceptions (both raised when YouTube blocks the source IP). Catch them explicitly rather than string-matching exception messages — string matching is brittle across library versions and localized messages.
+
+Update the imports at the top of [app/services/youtube.py](app/services/youtube.py):
+
+```python
+from youtube_transcript_api import (
+    IpBlocked,
+    NoTranscriptFound,
+    RequestBlocked,
+    TranscriptsDisabled,
+    YouTubeTranscriptApi,
+)
+```
+
+In `_fetch_transcript`, make the typed exception mapping cover the **entire transcript retrieval flow**, not just `YouTubeTranscriptApi().list(video_id)`. That matters because `transcript.fetch()` inside `_to_segments(...)` is another blocking network call and can fail with the same IP-block / transport exceptions. The plan should therefore keep `_fetch_transcript` wrapped in one outer `try` that covers:
+
+- `YouTubeTranscriptApi().list(video_id)`
+- the tier selection logic
+- every `transcript.fetch()` call inside `_to_segments(...)`
+
+Keep the inner `try / except NoTranscriptFound: pass` handlers around each tier in place — those are tier-selection control flow (i.e., "try the next tier"), not error reporting, and collapsing them into the outer `try` would change behavior.
+
+Add a dedicated `except (RequestBlocked, IpBlocked)` clause **before** the generic `except Exception`, alongside the existing handling for `TranscriptsDisabled` and `VideoUnavailable`:
+
+```python
+except (RequestBlocked, IpBlocked) as exc:
+    return IngestionError(
+        error_code="TRANSCRIPT_IP_BLOCKED",
+        message=(
+            "YouTube is blocking transcript requests from this server's IP. "
+            "This typically happens on cloud VMs. Configure a residential proxy "
+            "via WEBSHARE_PROXY_USERNAME / WEBSHARE_PROXY_PASSWORD."
+        ),
+        recoverable=True,
+    )
+```
+
+The existing generic `except Exception` continues to handle everything else with `TRANSCRIPT_FETCH_FAILED`. This turns the current cryptic 20-line error into a clear, actionable signal in logs and API responses, with no fragile substring matching, and it ensures late failures during `transcript.fetch()` do not leak past `_fetch_transcript` untyped.
+
+### 6. UI wiring — surface the new error code
+
+`app/templates/partials/error.html` has a fixed `error_configs` map; unknown error codes fall back to a generic "Something Went Wrong" title with no hint. Add a new entry so the new error code has a proper title, hint, and icon:
+
+```jinja
+'TRANSCRIPT_IP_BLOCKED': {
+  'icon': 'ban',
+  'title': 'Transcript Temporarily Unavailable',
+  'hint': 'YouTube is blocking transcript requests from this server. The operator has been notified; please try again later.',
+  'color': 'amber',
+  'recoverable': true,
+},
+```
+
+`recoverable: true` gives the user a retry button (useful if the operator has just provisioned the proxy). The hint is end-user-facing, not operator-facing; the operator-facing details are in the server logs and the `message` field of the API response.
+
+### 7. Tests in [tests/test_youtube.py](tests/test_youtube.py)
+
+- Unit test `_build_transcript_api()`: with no Webshare creds (`webshare_proxy_enabled` false) returns a vanilla `YouTubeTranscriptApi`; with both Webshare creds set returns one whose `proxy_config` is a `WebshareProxyConfig` carrying the expected username/password.
+- Unit test the settings validator: exactly-one-of-two Webshare vars set raises; both set or neither set validate cleanly. Be explicit about test technique here: because [app/config.py](app/config.py) creates `settings = Settings()` at import time, config-focused tests should instantiate `Settings(...)` directly (or reload the module intentionally), not rely on mutating env vars after import and hoping the singleton updates.
+- Unit test the IP-block error mapping in **both** network phases:
+  - patch `YouTubeTranscriptApi.list` to raise `RequestBlocked` (and separately `IpBlocked`) and assert `_fetch_transcript` returns `IngestionError(error_code="TRANSCRIPT_IP_BLOCKED", recoverable=True)`;
+  - patch a selected transcript object's `fetch()` to raise `RequestBlocked` and assert it maps to the same `TRANSCRIPT_IP_BLOCKED` error instead of escaping.
+- Unit test the generic late-failure path too: patch `transcript.fetch()` to raise a non-blocking exception and assert `_fetch_transcript` returns `TRANSCRIPT_FETCH_FAILED` rather than crashing out of the service.
+- Unit test the `to_thread` offload: in `ingest_video`, patch `asyncio.to_thread` to an `AsyncMock` and assert it is awaited exactly once with `_fetch_transcript` as the first positional arg and `video_id` as the second, confirming the blocking call doesn't run on the event loop. For service-level tests, monkeypatch `app.services.youtube.settings` directly rather than relying on env changes to mutate the already-imported singleton.
+
+All tests use monkeypatching only — no network calls.
+
+### 8. Documentation
+
+Add a self-contained "Transcript fetching on cloud VMs" section to [docs/deployment.md](docs/deployment.md) covering:
+
+**Why it's needed** — one paragraph: YouTube blocks transcript requests from cloud-datacenter IPs (AWS, GCP, Azure, DO, Hetzner, etc.). The fix is to route transcript requests through a residential proxy. Not required for local dev.
+
+**Which Webshare plan to buy — this is the common mistake.** `WebshareProxyConfig` is built for Webshare's **Residential** (rotating) proxy product. The free tier and the "Proxy Server" / "Static Residential" plans use datacenter IPs and will still be blocked by YouTube. Pricing starts around $3–6/month for the smallest residential tier. Signup at [webshare.io](https://www.webshare.io/).
+
+**Where to find the credentials.** In the Webshare dashboard, navigate to the **Proxy → Proxy Settings** (or **Residential → Settings**) page. Webshare issues a dedicated **Proxy Username** and **Proxy Password** per subaccount — these are *not* your Webshare login email and password. Copy both values verbatim.
+
+**What to put in `.env`.** Exactly two variables; do not set any others:
+
+```bash
+WEBSHARE_PROXY_USERNAME=<from Webshare dashboard>
+WEBSHARE_PROXY_PASSWORD=<from Webshare dashboard>
+```
+
+Endpoint defaults (`p.webshare.io:80`, rotation enabled) are applied automatically by `WebshareProxyConfig`. Do not override `domain_name` or `proxy_port` — doing so can silently route traffic through the wrong Webshare product.
+
+**Optional tuning (not in this plan, but documented so operators know the knobs exist).** If you later want to constrain exit countries (some YouTube videos are geo-restricted) or tune retries, `WebshareProxyConfig` also accepts `filter_ip_locations=["US", "CA", "GB"]` and `retries_when_blocked=N` (default 10). Adding these is a one-line change and intentionally not implemented yet.
+
+**How to verify before restart.** From the VM, confirm the proxy works independently of the app. Use shell vars or literal placeholders for the test command; do not assume they already exist in the shell just because they will later live in `.env`:
+
+```bash
+export WEBSHARE_PROXY_USERNAME='<from Webshare dashboard>'
+export WEBSHARE_PROXY_PASSWORD='<from Webshare dashboard>'
+curl --proxy-user "${WEBSHARE_PROXY_USERNAME}-rotate:${WEBSHARE_PROXY_PASSWORD}" \
+  -x http://p.webshare.io:80 \
+  https://api.ipify.org
+```
+
+A successful response prints a residential-looking IP that is *not* the VM's own IP. If `curl` hangs, returns a 407, or prints the VM's IP, the credentials or plan type are wrong — fix that before restarting the service. `--proxy-user` is preferred over embedding credentials directly in the proxy URL because it is less brittle if the password contains URL-special characters.
+
+Mirror the two env-var lines and a one-sentence pointer to this doc in [`.env.example`](.env.example) so VM operators see them when they copy the file.
+
+## Deliberately NOT in this plan (discuss if you want them in)
+
+- **Whisper / Gemini audio ASR fallback.** The provider seam is designed so this slots in as a new provider or a post-fail fallback, but it's a meaningful addition (cost, code, audio download which itself needs a proxy) — deserves its own plan.
+- **User-pasted transcript UX fallback.** UI work, scope-expanding.
+- **Generic HTTP proxy provider.** Same interface, trivial to add later; skipping unless you want it now for a self-hosted tunnel (Pi/Tailscale/Cloudflare Tunnel).
+- **Third-party transcript-API vendors** (SearchAPI, Supadata, etc.). Possible as another provider, but Webshare is cheaper, library-native, and has one less vendor in the critical path.
+
+## Rollout
+
+1. Merge changes. With no Webshare credentials set, `webshare_proxy_enabled` is `False` and behavior is identical to today, so local dev and tests keep passing unchanged.
+2. **Sign up at [webshare.io](https://www.webshare.io/)** and buy the smallest **Residential** (rotating) plan — ~$3–6/mo. **Do not use the free tier or "Proxy Server" plan**: those are datacenter IPs and YouTube still blocks them. `WebshareProxyConfig` in `youtube-transcript-api` is built for the Residential product specifically.
+3. In the Webshare dashboard, open **Proxy → Proxy Settings** and copy the dashboard-issued **Proxy Username** and **Proxy Password** (not your Webshare login email/password).
+4. From the VM, verify the proxy works before touching the app:
+
+   ```bash
+   export WEBSHARE_PROXY_USERNAME='<from Webshare dashboard>'
+   export WEBSHARE_PROXY_PASSWORD='<from Webshare dashboard>'
+   curl --proxy-user "${WEBSHARE_PROXY_USERNAME}-rotate:${WEBSHARE_PROXY_PASSWORD}" \
+     -x http://p.webshare.io:80 \
+     https://api.ipify.org
+   ```
+
+   A residential-looking IP that is not the VM's own IP confirms the credentials and plan type are correct.
+5. Get the two vars onto the dev VM. `.env` lives only on the VM (`/opt/vidsense/.env`) — it is not shipped by [deploy/update.sh](deploy/update.sh) or [.github/workflows/deploy.yml](.github/workflows/deploy.yml), which only `git pull` + `uv sync` + `systemctl restart`. So:
+   - SSH to the VM and append the two lines to `/opt/vidsense/.env` as the `vidsense` service user so ownership stays correct:
+
+     ```bash
+     ssh <admin>@<dev-vm>
+     sudo -u vidsense tee -a /opt/vidsense/.env >/dev/null <<'EOF'
+     WEBSHARE_PROXY_USERNAME=<from Webshare dashboard>
+     WEBSHARE_PROXY_PASSWORD=<from Webshare dashboard>
+     EOF
+     sudo chmod 600 /opt/vidsense/.env
+     ```
+
+   - If `/opt/vidsense/.env` already has old `WEBSHARE_PROXY_*` lines, edit/replace them rather than blindly appending duplicates.
+   - Leave `domain_name`, `proxy_port`, and location filters unset — the `WebshareProxyConfig` defaults are correct.
+6. Restart the service to pick up the new env vars. Either path works:
+   - **On the VM:** `sudo -u vidsense bash /opt/vidsense/deploy/update.sh main` (re-runs the normal deploy flow and its HTTP health probe). The startup `model_validator` only catches the **half-configured** case (exactly one of `WEBSHARE_PROXY_USERNAME` / `WEBSHARE_PROXY_PASSWORD` set); a wrong-but-complete credential (both set, one incorrect) will boot cleanly and only surface at request time as `TRANSCRIPT_IP_BLOCKED`. The step-4 `curl --proxy-user ...` smoke test is what catches the wrong-but-complete case *before* restarting the service.
+   - **From GitHub:** Actions → **Deploy** → **Run workflow** (`environment=dev`, `branch=main`), or `gh workflow run deploy.yml -f environment=dev -f branch=main`.
+
+   Either way, once `update.sh`'s health probe reports "serving", `webshare_proxy_enabled` is `True` in the live process. Verify by retrying the previously failing video; logs should no longer show `TRANSCRIPT_IP_BLOCKED`, and `sudo journalctl -u vidsense -n 50` should show a successful ingestion.
+7. Rollback, if Webshare itself goes bad: SSH back in, remove the two lines from `/opt/vidsense/.env` (or comment them out), and re-run `deploy/update.sh`. With both vars unset, `webshare_proxy_enabled` is `False` and the service reverts to the direct path (same behavior as today). The IP-block error code will come back for users until the proxy is restored, which is the correct failure mode.

--- a/.cursor/plans/github_ci_cd_workflows_2ab0d460.plan.md
+++ b/.cursor/plans/github_ci_cd_workflows_2ab0d460.plan.md
@@ -1,0 +1,417 @@
+---
+name: github ci cd workflows
+overview: "Add GitHub Actions: a PR-triggered lint + unit-test workflow now, plus the scaffolding (reusable job, branch protection, environments, deploy workflow shell) for later dev/prod VM deploys that match the existing uv + systemd model."
+todos:
+  - id: ruff_baseline
+    content: Add Ruff config + dev dep to pyproject.toml and commit a one-shot ruff --fix / format baseline PR
+    status: pending
+  - id: ci_workflow
+    content: Create .github/workflows/ci.yml with lint and test jobs (workflow_call-enabled, uv cache, concurrency)
+    status: pending
+  - id: branch_protection
+    content: Enable branch protection on main requiring lint + test status checks
+    status: pending
+  - id: environments
+    content: Create GitHub Environments dev and prod with SSH_HOST/SSH_USER/SSH_PRIVATE_KEY/DEPLOY_BRANCH secrets; require reviewers on prod
+    status: pending
+  - id: deploy_update_script
+    content: Add deploy/update.sh (git pull + uv sync + systemctl restart) and sudoers rule note in bootstrap.sh
+    status: pending
+  - id: deploy_workflow
+    content: Create .github/workflows/deploy.yml that reuses ci.yml and SSHes to the selected environment
+    status: pending
+  - id: optional_extras
+    content: "Optional later: mypy job, Dependabot, CODEOWNERS, /healthz smoke test"
+    status: pending
+isProject: false
+---
+
+# GitHub CI/CD for VidSense
+
+## Goals
+
+1. Every PR to `main` (and every push updating that PR) runs **lint + unit tests** automatically and reports status on the PR.
+2. The same machinery is reusable from a future **deploy workflow** (dev and prod VMs), so we don't rebuild CI later.
+3. Keep it simple and close to how the repo already works: `uv`, pytest, systemd-managed VM.
+
+## Design at a glance
+
+```mermaid
+flowchart LR
+    PR[PR opened/updated] --> CI[ci.yml: lint + tests]
+    CI -->|status checks| PR
+    Main[push to main] --> CI
+    Main --> DeployDev[deploy.yml: env=dev, auto]
+    Tag[manual dispatch / tag] --> DeployProd[deploy.yml: env=prod, gated]
+    DeployDev --> DevVM[(dev VM<br/>systemctl restart vidsense)]
+    DeployProd --> ProdVM[(prod VM<br/>systemctl restart vidsense)]
+```
+
+Key choices:
+
+- **Ruff** for lint + format check (single fast tool, zero extra deps at runtime; room to add mypy later as an extra job).
+- **`astral-sh/setup-uv@v5`** for uv + Python version from `.python-version`, with cache keyed on `uv.lock`.
+- **One reusable CI job** (`ci.yml`) callable both from PR triggers and before deploy, so we never deploy a red build.
+- **Deploy over SSH** (git pull + `uv sync` + `systemctl restart vidsense`) — mirrors [deploy/bootstrap.sh](deploy/bootstrap.sh) exactly, so dev/prod stay identical in shape. Deferred implementation, but scaffolded now.
+- **GitHub Environments** (`dev`, `prod`) to hold per-env secrets (SSH key, host, deploy path) and apply required reviewers on prod.
+
+## Execution coordination
+
+### Working branch
+
+All work lands on the existing branch **`greg/25-add-ai`** (created for issue [#25](https://github.com/grigory93/vidsense/issues/25)). Multiple PRs will be opened against `main` over the course of execution. `greg/25-add-ai` may be reused sequentially (after each PR merges, rebase/reset onto `main` and keep going) or short-lived child branches (e.g. `greg/25-ci`, `greg/25-deploy-scaffold`) can be created off `main` when two independent changes need to be in review at the same time. The issue closes when the final PR merges, via `Fixes #25` in the last PR's body.
+
+### PR slicing
+
+The phases split into the PRs below. Ordering between PR 1 and PR 2 is hard — everything else is flexible.
+
+- **PR 1 — `style: ruff baseline`**
+  - Phase 1.1 (Ruff dep + `[tool.ruff]` config in [pyproject.toml](pyproject.toml)) and Phase 1.3 (committed `ruff --fix` + `ruff format` diff in one go).
+  - No CI yet. Must merge before PR 2.
+- **PR 2 — `ci: add lint and test workflow`**
+  - Phase 1.2 (`.github/workflows/ci.yml`).
+  - After merge, wait for the first green run on `main`, then enable branch protection (Phase 1.4, manual step A3 below).
+- **PR 3 — `deploy: add update.sh and sudoers note`**
+  - Phase 2.3 (new `deploy/update.sh`) + Phase 2.2 note added to [deploy/bootstrap.sh](deploy/bootstrap.sh). Independent of PR 2; can land in parallel or after.
+- **PR 4 — `ci: add deploy workflow (dispatch-only)`**
+  - Phase 3.1 `.github/workflows/deploy.yml`, but with the `on: push: branches: [main]` trigger **omitted** — only `workflow_dispatch` initially.
+  - Merges only after VM prerequisites (Group C) and environment secrets (Group D) exist, and after a manual SSH dry-run from laptop succeeds (C5).
+- **PR 5 — `ci: enable auto-deploy to dev on push to main`**
+  - One-line change adding `on: push: branches: [main]` back to `deploy.yml`. Includes `Fixes #25`.
+  - Opens only after PR 4's dispatch-deploy has been exercised successfully end-to-end at least once (E1).
+
+### Execution sequence with handoffs
+
+```mermaid
+flowchart TD
+    PR1[PR 1: ruff baseline] --> M1{Human A1: review + merge}
+    M1 --> PR2[PR 2: ci.yml]
+    PR2 --> M2{Human A2: merge + wait for green run}
+    M2 --> A3{Human A3: enable branch protection}
+    A3 --> PR3[PR 3: update.sh + sudoers doc]
+    PR3 --> M3{Human: review + merge}
+    M3 --> C1{Human C1 to C4: VM setup per env}
+    C1 --> B1{Human B1 B2: SSH key + secret values}
+    B1 --> D1{Human D1 to D3: GitHub envs + secrets + reviewers}
+    D1 --> C5{Human C5: manual SSH deploy dry-run}
+    C5 --> PR4[PR 4: deploy.yml dispatch-only]
+    PR4 --> M4{Human: merge}
+    M4 --> E1{Human E1: trigger dispatch to dev}
+    E1 --> E2{Human E2: repeat for prod, gated by required reviewers}
+    E2 --> PR5[PR 5: enable push-to-main auto-deploy]
+    PR5 --> M5{Human: merge; closes issue 25}
+```
+
+### Human-in-the-loop checklist
+
+Grouped by what they block. Items in a group are independent within the group but the group as a whole is blocking for its downstream PR.
+
+**Group A — Merges and branch protection (blocks PRs 2 onward)**
+
+- A1. Review and merge PR 1 before PR 2 is opened.
+- A2. Review and merge PR 2; wait for the first green `lint` + `test` run on `main`.
+- A3. Settings → Branches → add rule for `main`: require PR before merging, require status checks `lint` and `test`, require branches up to date. (Check names only appear in the dropdown after they have run once.)
+
+**Group B — Secret values you control (blocks PR 4)**
+
+- B1. Generate a dedicated ed25519 SSH keypair for GitHub Actions deploy: `ssh-keygen -t ed25519 -f deploy_key -N "" -C "github-actions@vidsense"`. Decide where the private key lives outside the repo (password manager or local secure store).
+- B2. For each environment, collect values: `SSH_HOST`, `SSH_USER` (typically `vidsense`), `SSH_PRIVATE_KEY` (the file from B1), `DEPLOY_BRANCH` (`main` for dev, release branch/tag for prod), optional `DEPLOY_PATH` (`/opt/vidsense`), recommended `SSH_KNOWN_HOSTS` (output of `ssh-keyscan -H <host>`).
+
+**Group C — VM-side (blocks deploy verification for a given env)**
+
+- C1. Provision the VM for that env; run [deploy/bootstrap.sh](deploy/bootstrap.sh) if not already done.
+- C2. After PR 3 is on the VM (via `git pull`), ensure `/opt/vidsense/deploy/update.sh` is executable (`chmod +x`).
+- C3. Install sudoers rule: `sudo visudo -f /etc/sudoers.d/vidsense` containing `vidsense ALL=(root) NOPASSWD: /bin/systemctl restart vidsense, /bin/systemctl status vidsense`.
+- C4. Append the deploy public key (B1's `.pub`) to `~vidsense/.ssh/authorized_keys`. Ensure `~vidsense/.ssh` is `700` and the file is `600`, owned by `vidsense`.
+- C5. Dry-run from your laptop with the deploy private key loaded: `ssh vidsense@<host> bash /opt/vidsense/deploy/update.sh main`. Confirm the final `systemctl status` shows `Active: active (running)`.
+
+**Group D — GitHub-side environment config (blocks PR 4 merge)**
+
+- D1. Create `dev` and `prod` environments (web UI, or `gh api --method PUT /repos/grigory93/vidsense/environments/dev`).
+- D2. Set each environment's secrets from Group B (`gh secret set --env dev --name SSH_HOST ...` etc.).
+- D3. On `prod` only, enable **Required reviewers** and add yourself (or release approvers). This is the gate that prevents accidental prod deploys.
+
+**Group E — Go-live verification (between PR 4 and PR 5)**
+
+- E1. Actions → Deploy → Run workflow → select `dev`. Confirm green; confirm the live app reflects the new commit.
+- E2. Repeat for `prod` once prod-side Group C + D are done; verify the required-reviewer approval gate fires before the SSH step runs.
+- E3. Only after E1 (and ideally E2) succeed, open PR 5 to add the `on: push: branches: [main]` auto-deploy trigger.
+
+**Group F — Optional housekeeping (any time after Group A)**
+
+- F1. `.github/dependabot.yml` for `pip` (uv) + `github-actions` ecosystems.
+- F2. `CODEOWNERS` + `.github/pull_request_template.md`.
+- F3. `/healthz` route in [main.py](main.py) + `curl -fsS https://$SSH_HOST/healthz` smoke step at the end of `deploy.yml`.
+- F4. Add a `mypy` job to `ci.yml`.
+
+### What I can drive end-to-end vs. where I stop and wait
+
+I can do: branch/commit/push, file edits, `gh pr create`, `gh secret set` (once you provide values), `gh api` calls for environments and branch protection, local `ruff --fix`, local `uv lock`.
+
+I stop and wait on: any SSH into a VM, any step that needs a value only you have (SSH private key, hostnames, approver identities), any merge click (so we keep a human review in the loop), and any "observe the live behavior" verification (C5, E1, E2). At each wait point I'll clearly say "waiting on human step X<n>" so handoff is unambiguous.
+
+## Phase 1 — Lint + test CI on PRs (do now)
+
+### 1.1 Add Ruff config to `pyproject.toml`
+
+Append a minimal, opinionated config and add `ruff` to the `dev` group:
+
+```toml
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+    "pytest-asyncio>=1.3.0",
+    "ruff>=0.7.0",
+]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+extend-exclude = ["data", "logs", ".venv"]
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "B", "UP"]  # pycodestyle, pyflakes, isort, bugbear, pyupgrade
+ignore = ["E501"]  # line length handled by formatter
+
+[tool.ruff.format]
+quote-style = "double"
+```
+
+Rationale: single tool, fast, covers imports + common bugs; formatter check catches style drift without forcing a big reformat commit on day one.
+
+### 1.2 Create `.github/workflows/ci.yml`
+
+Runs on PRs and pushes to `main`. Uses `workflow_call` so deploy can reuse it.
+
+```yaml
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_call: {}
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - run: uv sync --group dev --frozen
+      - run: uv run ruff check .
+      - run: uv run ruff format --check .
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - run: uv sync --group dev --frozen
+      - run: uv run pytest -q
+```
+
+Notes:
+
+- No secrets needed: [tests/conftest.py](tests/conftest.py) already sets `APP_SECRET_KEY`, `YOUTUBE_API_KEY`, `APP_ALLOWED_HOSTS` before imports, so tests run clean on a fresh runner.
+- `--frozen` ensures the lockfile is authoritative; flags drift in `uv.lock` as a CI failure.
+- `concurrency` cancels superseded PR runs when new commits arrive.
+
+### 1.3 One-time Ruff baseline
+
+Before the workflow can pass, run locally once:
+
+```bash
+uv run ruff check --fix .
+uv run ruff format .
+```
+
+Commit the result as a single "style: ruff baseline" PR so the first CI-enforced PR is not drowning in unrelated fixups.
+
+### 1.4 Require the checks on `main`
+
+In GitHub → Settings → Branches → add rule for `main`:
+
+- Require PR before merging.
+- Require status checks: `lint`, `test`.
+- Require branches up to date.
+
+## Phase 2 — Scaffolding for later VM deploy (stub now, wire later)
+
+This is documented and stubbed so Phase 3 is a small, obvious change.
+
+### 2.1 GitHub Environments
+
+Create two environments in the repo settings: **`dev`** and **`prod`**.
+
+Per-environment secrets (same names in each):
+
+- `SSH_HOST` — e.g. `dev.vidsense.info`
+- `SSH_USER` — usually `vidsense` (the systemd service user)
+- `SSH_PRIVATE_KEY` — key authorized on that VM for `vidsense`
+- `DEPLOY_BRANCH` — `main` for dev, a release tag/branch for prod
+- Optional: `DEPLOY_PATH` (default `/opt/vidsense`)
+
+On `prod`: enable **Required reviewers** so deploys need approval.
+
+### 2.2 Service-user sudo for restart
+
+On each VM, add a minimal sudoers rule so the deploy user can restart the service without a password:
+
+```
+vidsense ALL=(root) NOPASSWD: /bin/systemctl restart vidsense, /bin/systemctl status vidsense
+```
+
+Document this as a one-line addition to [deploy/bootstrap.sh](deploy/bootstrap.sh) in Phase 3.
+
+### 2.3 Add a deploy entry-point script under `deploy/`
+
+New file `deploy/update.sh` (idempotent, safe to re-run):
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+BRANCH="${1:-main}"
+cd /opt/vidsense
+git fetch --prune origin
+git checkout "$BRANCH"
+git pull --ff-only origin "$BRANCH"
+uv sync --frozen
+sudo /bin/systemctl restart vidsense
+sudo /bin/systemctl status vidsense --no-pager | head -n 20
+```
+
+This keeps the deploy logic on the VM (versioned, reviewable) and makes the GitHub Action a thin trigger.
+
+## Phase 3 — Deploy workflow (implement when ready)
+
+### 3.1 `.github/workflows/deploy.yml` (sketch)
+
+```yaml
+name: Deploy
+
+on:
+  push:
+    branches: [main]          # auto-deploy to dev
+  workflow_dispatch:
+    inputs:
+      environment:
+        type: choice
+        options: [dev, prod]
+        default: dev
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml   # never deploy a red build
+
+  deploy:
+    needs: ci
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment || 'dev' }}
+    steps:
+      - uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: Add host key
+        run: ssh-keyscan -H "${{ secrets.SSH_HOST }}" >> ~/.ssh/known_hosts
+      - name: Trigger update
+        run: |
+          ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} \
+            "bash /opt/vidsense/deploy/update.sh ${{ secrets.DEPLOY_BRANCH }}"
+```
+
+Behavior:
+
+- Push to `main` → CI runs → auto-deploy to **dev**.
+- Prod deploys are **manual only** (`workflow_dispatch` with `environment=prod`), gated by required reviewers on the `prod` environment.
+
+### 3.2 Optional later additions (not now)
+
+- **Smoke test step** after deploy: `curl -fsS https://$SSH_HOST/healthz` (would need a `/healthz` route in [main.py](main.py)).
+- **mypy** as a third CI job.
+- **Dependabot** (`.github/dependabot.yml`) for `uv`/pip and `github-actions` ecosystems.
+- **CODEOWNERS** + PR template under `.github/`.
+
+## Execution strategy
+
+Tracking issue: [grigory93/vidsense#25](https://github.com/grigory93/vidsense/issues/25). Working branch root: `greg/25-add-ai` (already exists).
+
+Multiple PRs, each with a child branch off `greg/25-add-ai`, opened against `main` in the order below. Each PR carries `Refs #25` in its body; the final PR uses `Fixes #25`. We keep the ordering because the first two PRs have a hard dependency (Ruff baseline must land before CI is enforced).
+
+```mermaid
+flowchart TD
+    Main[(main)] --> Base[greg/25-ruff-baseline<br/>PR 1: style + config]
+    Main --> CI[greg/25-ci<br/>PR 2: ci.yml]
+    Main --> Scaf[greg/25-deploy-scaffold<br/>PR 3: update.sh + bootstrap.sh note]
+    Main --> Dep[greg/25-deploy-workflow<br/>PR 4: deploy.yml]
+    Base -. merge first .-> CI
+    CI -. merge + protect main .-> Scaf
+    Scaf -. VM prereqs done .-> Dep
+```
+
+Why multiple PRs: each is small, independently reviewable, and the state of `main` is always deployable. `greg/25-add-ai` is the umbrella label for the effort; child branches are where code lives.
+
+Proposed PR sequence:
+
+- **PR 1 - `greg/25-ruff-baseline`**: `pyproject.toml` Ruff config + dev dep, plus the mechanical `ruff --fix` / `ruff format` diff. Pure style/config. No CI yet.
+- **PR 2 - `greg/25-ci`**: `.github/workflows/ci.yml`. First PR to show a green `lint` + `test` check. After merge, enable branch protection on `main`.
+- **PR 3 - `greg/25-deploy-scaffold`**: `deploy/update.sh` + sudoers rule note appended to `deploy/bootstrap.sh`. No workflow yet; safe to merge any time after PR 2.
+- **PR 4 - `greg/25-deploy-workflow`**: `.github/workflows/deploy.yml`, wired for **dev only** (both environments created in GitHub, but the job targets `environment: dev`). Initially `workflow_dispatch` only. Push-to-main auto-deploy to dev is enabled in a tiny follow-up PR *after* a successful manual dispatch.
+- **Optional follow-ups** (not blocking): mypy job, `/healthz` route + smoke test, Dependabot, CODEOWNERS, wiring `prod` into `deploy.yml` when a prod VM exists.
+
+**Confirmed scope (from planning Q&A):**
+
+- **VMs**: dev VM exists; no prod VM yet. Plan ships Phase 3 wired for dev. The `prod` environment is still created (so secrets/reviewers are configured) but `deploy.yml` does not target it yet; add a one-line follow-up PR when prod comes online.
+- **PR cadence**: sequential. Agent opens one PR, stops, waits for merge (and, after PR 2, for branch protection to be enabled) before opening the next. Between PRs the agent reports: what landed, what the user must do, and what the next PR will contain.
+- **Ruff strictness (PR 1)**: `select = ["E","F","W","I","B","UP"]` plus `ruff format --check` enforced from day one. Baseline PR will contain the full `ruff --fix` + `ruff format` diff. One-and-done; no style debates later.
+- **SSH key for dev deploy**: agent generates a fresh unencrypted ed25519 keypair locally during PR 4 work (`ssh-keygen -t ed25519 -f deploy_key_dev -N ""`). Public key printed for the user to append to `~vidsense/.ssh/authorized_keys` on the dev VM; private key piped into `gh secret set --env dev SSH_PRIVATE_KEY`. Local copies deleted after. The key is VidSense-specific and least-privilege (only authorizes `vidsense` service user, only allows the two sudoer'd `systemctl` commands).
+
+### Human-in-the-loop steps
+
+The agent can author commits/PRs, run `gh` calls, and script infrastructure-as-code. It cannot merge PRs, touch the VMs, or invent secret values. These are the hand-offs:
+
+**A. Merging / enabling protection** (GitHub web or approving `gh` PR merges)
+
+1. Approve and merge **PR 1** (Ruff baseline) before PR 2 opens for review.
+2. Approve and merge **PR 2** (CI). Watch the first green run on `main`.
+3. Enable branch protection on `main`: Settings -> Branches -> require `lint` + `test` status checks, require PR before merging, require branches up to date. *Must be done after step 2 succeeds so the check names appear in the dropdown.*
+4. Approve and merge **PR 3** and **PR 4** when ready.
+
+**B. Secret values** (agent runs `gh secret set ...` but values come from you)
+
+5. Generate or supply the deploy SSH keypair. Decide where the private key is stored (password manager, vault, local disk). Public key goes on the VMs (step C8).
+6. Provide per-environment values for `SSH_HOST`, `SSH_USER` (usually `vidsense`), `DEPLOY_BRANCH` (e.g. `main` for dev, a tag or release branch for prod), optionally `DEPLOY_PATH`.
+7. Provide pinned `SSH_KNOWN_HOSTS` for prod (`ssh-keyscan <prod-host>` from a trusted location).
+8. In GitHub web: set `prod` environment required reviewers (click-only; easier than `gh api` with user IDs).
+
+**C. VM-side setup** (only you can do these; inherently manual)
+
+9. Ensure `dev` and `prod` VMs exist and have run `deploy/bootstrap.sh`.
+10. Append the deploy public key to `~vidsense/.ssh/authorized_keys` on each VM.
+11. Install the sudoers rule on each VM: `sudo visudo -f /etc/sudoers.d/vidsense` with content `vidsense ALL=(root) NOPASSWD: /bin/systemctl restart vidsense, /bin/systemctl status vidsense`.
+
+**D. Verification gates**
+
+12. Manual smoke from your laptop: `ssh vidsense@<dev-host> bash /opt/vidsense/deploy/update.sh main`. Confirm `systemctl status` shows `active (running)`. Only then add `on: push: branches: [main]` to `deploy.yml`.
+13. First prod deploy: trigger manually via `workflow_dispatch` and approve the required-reviewer gate. Confirm the pinned `SSH_KNOWN_HOSTS` matches so no TOFU prompt.
+
+Anything outside A-D is fully automatable.
+
+## Risk / things to watch
+
+1. **First CI run fails without the Ruff baseline.** Merging PR 2 before PR 1 makes the tree red (every unformatted file becomes an error) and blocks every other open PR. Mitigation: strict PR 1 → PR 2 ordering (steps A1–A2). If the baseline diff is too noisy to review, narrow `select` to `["E", "F", "I"]` first and add `B` / `UP` in a follow-up PR so the initial reformat is smaller.
+2. **`uv sync --frozen` fails on lockfile drift.** Any change to [pyproject.toml](pyproject.toml) without a matching `uv lock` commit fails CI with `The lockfile at uv.lock needs to be updated`. This is intentional — it forces lockfile updates through review. Add a one-line note to [README.md](README.md) ("commit both `pyproject.toml` and `uv.lock`"), and optionally add an explicit `uv lock --check` step before `uv sync --frozen` for a clearer error message.
+3. **Branch protection chicken-and-egg.** The `lint` and `test` check names only appear in Settings → Branches' status-check dropdown *after* they have run once on `main`. Enabling protection first can make the baseline PR unmergeable with no checks ever able to pass. Correct order: merge PR 1 → merge PR 2 → observe the first green run on `main` → then enable protection (A3). Additional caveat: any future rename of these job names silently disables enforcement (the rule keeps the old name "expected" forever) — job renames must be paired with a Settings → Branches update.
+4. **Don't enable deploy before VM prerequisites exist.** The deploy job assumes `/opt/vidsense/deploy/update.sh`, a NOPASSWD sudoers rule, and an authorized SSH key are all on the VM. Missing pieces fail in characteristic ways: missing `update.sh` → clean fast failure; missing sudoers → job hangs on `sudo: a password is required` or fails with `no tty present`; missing authorized key → `Permission denied (publickey)`; worst case partial success where `git pull` wins but `systemctl restart` fails and the VM runs old code from new files (a silent drift bug). Mitigations: PR 4 ships with dispatch-only trigger (no auto-push), Group E exercises it manually first, and `deploy/update.sh` should exit non-zero if `systemctl status` doesn't end in `active (running)` so partial deploys become red runs.
+5. **SSH host-key TOFU.** The deploy job sketch uses `ssh-keyscan -H "$SSH_HOST" >> ~/.ssh/known_hosts`, which trusts whatever answers on first contact. An MITM between the GitHub runner and your VM would be accepted silently. For prod (and ideally dev too), pin `SSH_KNOWN_HOSTS` as an environment secret — run `ssh-keyscan -H prod.host` once from a trusted network, paste the result into the secret, and in the workflow use `echo "$SSH_KNOWN_HOSTS" >> ~/.ssh/known_hosts` instead of keyscanning at job time.

--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,13 @@ APP_ALLOWED_HOSTS=localhost,127.0.0.1,::1
 # Production example:
 # APP_ALLOWED_HOSTS=vidsense.info,localhost,127.0.0.1
 
+# Webshare residential proxy (cloud VMs only — not needed for local dev).
+# YouTube blocks transcript requests from datacenter IPs. Setting both vars
+# routes transcript fetches through Webshare's rotating residential proxies.
+# See docs/deployment.md for which Webshare plan to buy and where to find the credentials.
+# WEBSHARE_PROXY_USERNAME=
+# WEBSHARE_PROXY_PASSWORD=
+
 # ---------------------------------------------------------------------------
 # Production notes
 # ---------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -60,6 +60,19 @@ With `APP_DEBUG=true` in `.env`, `python main.py` enables uvicorn reload when ru
 
 See also the **YouTube** block in [`.env.example`](./.env.example).
 
+### Transcript proxy (cloud VMs)
+
+On cloud VMs (AWS EC2, GCP, Azure, DigitalOcean, Hetzner, etc.) YouTube blocks unauthenticated transcript requests from datacenter IP ranges. The authenticated metadata and comments APIs that use `YOUTUBE_API_KEY` are not affected — only transcript fetching is blocked, which causes the whole ingestion pipeline to fail.
+
+To fix this, set two optional env vars to route transcript fetches through a [Webshare](https://www.webshare.io/) residential proxy:
+
+```bash
+WEBSHARE_PROXY_USERNAME=<from Webshare dashboard>
+WEBSHARE_PROXY_PASSWORD=<from Webshare dashboard>
+```
+
+Both vars are optional and **not needed for local development**. Setting exactly one triggers a clear startup error. See [Transcript fetching on cloud VMs](./docs/deployment.md#transcript-fetching-on-cloud-vms) in the deployment guide for which Webshare plan to buy, where to find the credentials, and how to verify the proxy before restarting the service.
+
 ---
 
 ## Development

--- a/app/config.py
+++ b/app/config.py
@@ -1,6 +1,6 @@
 import json
 
-from pydantic import AliasChoices, Field, computed_field, field_validator
+from pydantic import AliasChoices, Field, computed_field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 APP_SECRET_KEY_PLACEHOLDER = "change-me-in-production"
@@ -107,8 +107,32 @@ class Settings(BaseSettings):
         description="Ranked language preference for transcript selection. First match wins.",
     )
 
+    # Webshare residential proxy (transcript fetching on cloud VMs)
+    webshare_proxy_username: str = Field(
+        default="",
+        description="Webshare proxy username. If set together with webshare_proxy_password, "
+        "transcript fetches route through Webshare residential proxies.",
+    )
+    webshare_proxy_password: str = Field(
+        default="",
+        description="Webshare proxy password. See webshare_proxy_username.",
+    )
+
     # LLM retry config
     llm_max_retries: int = Field(default=2)
+
+    @model_validator(mode="after")
+    def _validate_webshare_pair(self) -> "Settings":
+        has_user = bool(self.webshare_proxy_username)
+        has_pass = bool(self.webshare_proxy_password)
+        if has_user != has_pass:
+            set_var = "WEBSHARE_PROXY_USERNAME" if has_user else "WEBSHARE_PROXY_PASSWORD"
+            missing_var = "WEBSHARE_PROXY_PASSWORD" if has_user else "WEBSHARE_PROXY_USERNAME"
+            raise ValueError(
+                f"{set_var} is set but {missing_var} is empty. "
+                "Both must be set together, or both must be omitted."
+            )
+        return self
 
     @field_validator("allowed_hosts_raw", mode="before")
     @classmethod
@@ -118,6 +142,11 @@ class Settings(BaseSettings):
         if isinstance(value, str):
             return value
         return str(value)
+
+    @computed_field
+    @property
+    def webshare_proxy_enabled(self) -> bool:
+        return bool(self.webshare_proxy_username and self.webshare_proxy_password)
 
     @computed_field
     @property

--- a/app/services/youtube.py
+++ b/app/services/youtube.py
@@ -326,9 +326,7 @@ def _fetch_transcript(
         try:
             transcript = transcript_list.find_generated_transcript(_EN_CODES)
             segments = _to_segments(transcript)
-            logger.info(
-                "Selected transcript: lang=en, source=auto_generated, video=%s", video_id
-            )
+            logger.info("Selected transcript: lang=en, source=auto_generated, video=%s", video_id)
             return (segments, TranscriptSourceType.auto_generated, "en")
         except NoTranscriptFound:
             pass
@@ -360,9 +358,7 @@ def _fetch_transcript(
         for lang in pref_langs:
             if lang in manual_by_lang:
                 segments = _to_segments(manual_by_lang[lang])
-                logger.info(
-                    "Selected transcript: lang=%s, source=manual, video=%s", lang, video_id
-                )
+                logger.info("Selected transcript: lang=%s, source=manual, video=%s", lang, video_id)
                 return (segments, TranscriptSourceType.manual, lang)
 
         # Tier 4: auto-generated transcript in preferred language order

--- a/app/services/youtube.py
+++ b/app/services/youtube.py
@@ -11,6 +11,7 @@ Responsibilities:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import re
@@ -21,11 +22,14 @@ import httpx
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from youtube_transcript_api import (
+    IpBlocked,
     NoTranscriptFound,
+    RequestBlocked,
     TranscriptsDisabled,
     YouTubeTranscriptApi,
 )
 from youtube_transcript_api._errors import VideoUnavailable
+from youtube_transcript_api.proxies import WebshareProxyConfig
 
 from app.config import settings
 from app.lang import normalize_language_code
@@ -268,6 +272,18 @@ async def _fetch_top_comments(video_id: str) -> list[dict[str, str]] | None:
 # ---------------------------------------------------------------------------
 
 
+def _build_transcript_api() -> YouTubeTranscriptApi:
+    """Return a YouTubeTranscriptApi, routed through Webshare if credentials are configured."""
+    if settings.webshare_proxy_enabled:
+        return YouTubeTranscriptApi(
+            proxy_config=WebshareProxyConfig(
+                proxy_username=settings.webshare_proxy_username,
+                proxy_password=settings.webshare_proxy_password,
+            )
+        )
+    return YouTubeTranscriptApi()
+
+
 def _fetch_transcript(
     video_id: str,
 ) -> tuple[list[dict], TranscriptSourceType, str] | IngestionError:
@@ -281,9 +297,110 @@ def _fetch_transcript(
       3. Manual transcript in a supported language (settings.supported_languages order)
       4. Auto-generated transcript in a supported language (same order)
     Falls through to the first available language if none of the above match.
+
+    The outer try/except covers the entire flow — including transcript.fetch()
+    calls inside _to_segments — so IP-block exceptions are caught regardless
+    of which network phase raises them.
     """
     try:
-        transcript_list = YouTubeTranscriptApi().list(video_id)
+        transcript_list = _build_transcript_api().list(video_id)
+
+        def _to_segments(transcript) -> list[dict]:
+            return [
+                {"text": s.text, "start": s.start, "duration": s.duration}
+                for s in transcript.fetch()
+            ]
+
+        _EN_CODES = ["en", "en-US", "en-GB"]
+
+        # Tier 1: manual English
+        try:
+            transcript = transcript_list.find_manually_created_transcript(_EN_CODES)
+            segments = _to_segments(transcript)
+            logger.info("Selected transcript: lang=en, source=manual, video=%s", video_id)
+            return (segments, TranscriptSourceType.manual, "en")
+        except NoTranscriptFound:
+            pass
+
+        # Tier 2: auto-generated English
+        try:
+            transcript = transcript_list.find_generated_transcript(_EN_CODES)
+            segments = _to_segments(transcript)
+            logger.info(
+                "Selected transcript: lang=en, source=auto_generated, video=%s", video_id
+            )
+            return (segments, TranscriptSourceType.auto_generated, "en")
+        except NoTranscriptFound:
+            pass
+
+        # Build lookup tables for tiers 3-4
+        try:
+            available = list(transcript_list)
+        except Exception:
+            available = []
+
+        if not available:
+            return IngestionError(
+                error_code="NO_TRANSCRIPT",
+                message="No transcript or caption source is available for this video.",
+            )
+
+        manual_by_lang: dict[str, object] = {}
+        generated_by_lang: dict[str, object] = {}
+        for t in available:
+            lang = normalize_language_code(t.language_code)
+            if t.is_generated:
+                generated_by_lang.setdefault(lang, t)
+            else:
+                manual_by_lang.setdefault(lang, t)
+
+        pref_langs = [normalize_language_code(lc) for lc in settings.supported_languages]
+
+        # Tier 3: manual transcript in preferred language order
+        for lang in pref_langs:
+            if lang in manual_by_lang:
+                segments = _to_segments(manual_by_lang[lang])
+                logger.info(
+                    "Selected transcript: lang=%s, source=manual, video=%s", lang, video_id
+                )
+                return (segments, TranscriptSourceType.manual, lang)
+
+        # Tier 4: auto-generated transcript in preferred language order
+        for lang in pref_langs:
+            if lang in generated_by_lang:
+                segments = _to_segments(generated_by_lang[lang])
+                logger.info(
+                    "Selected transcript: lang=%s, source=auto_generated, video=%s",
+                    lang,
+                    video_id,
+                )
+                return (segments, TranscriptSourceType.auto_generated, lang)
+
+        # Fallback: first available manual, then generated
+        if manual_by_lang:
+            lang, t = next(iter(manual_by_lang.items()))
+            segments = _to_segments(t)
+            logger.info(
+                "Selected transcript: lang=%s, source=manual (fallback), video=%s",
+                lang,
+                video_id,
+            )
+            return (segments, TranscriptSourceType.manual, lang)
+        if generated_by_lang:
+            lang, t = next(iter(generated_by_lang.items()))
+            segments = _to_segments(t)
+            logger.info(
+                "Selected transcript: lang=%s, source=auto_generated (fallback), video=%s",
+                lang,
+                video_id,
+            )
+            return (segments, TranscriptSourceType.auto_generated, lang)
+
+        return IngestionError(
+            error_code="NO_TRANSCRIPT",
+            message="No transcript or caption source is available for this video.",
+        )
+
     except TranscriptsDisabled:
         return IngestionError(
             error_code="TRANSCRIPTS_DISABLED",
@@ -294,99 +411,22 @@ def _fetch_transcript(
             error_code="VIDEO_UNAVAILABLE",
             message="This video is unavailable or private.",
         )
+    except (RequestBlocked, IpBlocked):
+        return IngestionError(
+            error_code="TRANSCRIPT_IP_BLOCKED",
+            message=(
+                "YouTube is blocking transcript requests from this server's IP. "
+                "This typically happens on cloud VMs. Configure a residential proxy "
+                "via WEBSHARE_PROXY_USERNAME / WEBSHARE_PROXY_PASSWORD."
+            ),
+            recoverable=True,
+        )
     except Exception as exc:
         return IngestionError(
             error_code="TRANSCRIPT_FETCH_FAILED",
             message=f"Could not fetch transcript: {exc}",
             recoverable=True,
         )
-
-    def _to_segments(transcript) -> list[dict]:
-        return [
-            {"text": s.text, "start": s.start, "duration": s.duration} for s in transcript.fetch()
-        ]
-
-    _EN_CODES = ["en", "en-US", "en-GB"]
-
-    # Tier 1: manual English
-    try:
-        transcript = transcript_list.find_manually_created_transcript(_EN_CODES)
-        segments = _to_segments(transcript)
-        logger.info("Selected transcript: lang=en, source=manual, video=%s", video_id)
-        return (segments, TranscriptSourceType.manual, "en")
-    except NoTranscriptFound:
-        pass
-
-    # Tier 2: auto-generated English
-    try:
-        transcript = transcript_list.find_generated_transcript(_EN_CODES)
-        segments = _to_segments(transcript)
-        logger.info("Selected transcript: lang=en, source=auto_generated, video=%s", video_id)
-        return (segments, TranscriptSourceType.auto_generated, "en")
-    except NoTranscriptFound:
-        pass
-
-    # Build lookup tables for tiers 3-4
-    try:
-        available = list(transcript_list)
-    except Exception:
-        available = []
-
-    if not available:
-        return IngestionError(
-            error_code="NO_TRANSCRIPT",
-            message="No transcript or caption source is available for this video.",
-        )
-
-    manual_by_lang: dict[str, object] = {}
-    generated_by_lang: dict[str, object] = {}
-    for t in available:
-        lang = normalize_language_code(t.language_code)
-        if t.is_generated:
-            generated_by_lang.setdefault(lang, t)
-        else:
-            manual_by_lang.setdefault(lang, t)
-
-    pref_langs = [normalize_language_code(lc) for lc in settings.supported_languages]
-
-    # Tier 3: manual transcript in preferred language order
-    for lang in pref_langs:
-        if lang in manual_by_lang:
-            segments = _to_segments(manual_by_lang[lang])
-            logger.info("Selected transcript: lang=%s, source=manual, video=%s", lang, video_id)
-            return (segments, TranscriptSourceType.manual, lang)
-
-    # Tier 4: auto-generated transcript in preferred language order
-    for lang in pref_langs:
-        if lang in generated_by_lang:
-            segments = _to_segments(generated_by_lang[lang])
-            logger.info(
-                "Selected transcript: lang=%s, source=auto_generated, video=%s", lang, video_id
-            )
-            return (segments, TranscriptSourceType.auto_generated, lang)
-
-    # Fallback: first available manual, then generated
-    if manual_by_lang:
-        lang, t = next(iter(manual_by_lang.items()))
-        segments = _to_segments(t)
-        logger.info(
-            "Selected transcript: lang=%s, source=manual (fallback), video=%s", lang, video_id
-        )
-        return (segments, TranscriptSourceType.manual, lang)
-    if generated_by_lang:
-        lang, t = next(iter(generated_by_lang.items()))
-        segments = _to_segments(t)
-        logger.info(
-            "Selected transcript: lang=%s, source=auto_generated (fallback), video=%s",
-            lang,
-            video_id,
-        )
-        return (segments, TranscriptSourceType.auto_generated, lang)
-
-    return IngestionError(
-        error_code="NO_TRANSCRIPT",
-        message="No transcript or caption source is available for this video.",
-    )
 
 
 def _build_raw_text(segments: list[dict]) -> str:
@@ -461,7 +501,9 @@ async def ingest_video(
     detected_lang = _detect_language(metadata)
 
     # 5. Fetch transcript (accepts any language; see _fetch_transcript ranking).
-    transcript_result = _fetch_transcript(video_id)
+    # Offloaded to a worker thread: youtube-transcript-api is synchronous (built
+    # on requests) and proxy retries can take tens of seconds.
+    transcript_result = await asyncio.to_thread(_fetch_transcript, video_id)
     if isinstance(transcript_result, IngestionError):
         return IngestionResult(success=False, error=transcript_result)
 

--- a/app/templates/partials/error.html
+++ b/app/templates/partials/error.html
@@ -69,6 +69,13 @@
     'color': 'red',
     'recoverable': false,
   },
+  'TRANSCRIPT_IP_BLOCKED': {
+    'icon': 'ban',
+    'title': 'Transcript Temporarily Unavailable',
+    'hint': 'YouTube is blocking transcript requests from this server. The operator has been notified; please try again later.',
+    'color': 'amber',
+    'recoverable': true,
+  },
 } %}
 
 {% set cfg    = error_configs.get(error_code, {'icon': 'exclamation', 'title': 'Something Went Wrong', 'hint': '', 'color': 'red', 'recoverable': false}) %}

--- a/docs/deployment-aws.md
+++ b/docs/deployment-aws.md
@@ -195,6 +195,8 @@ LLM_PROVIDER=openai
 OPENAI_API_KEY=sk-...
 ```
 
+> **EC2 is a cloud VM:** YouTube blocks unauthenticated transcript requests from AWS IP ranges. After the minimum settings above, also add `WEBSHARE_PROXY_USERNAME` and `WEBSHARE_PROXY_PASSWORD` to route transcript fetches through a residential proxy. See [Transcript fetching on cloud VMs](deployment.md#transcript-fetching-on-cloud-vms) for which plan to buy, where to find the credentials, and a pre-restart verification command.
+
 **Do not** paste secrets in the shell where history is recorded. Use `nano`
 or `vi` directly. After editing, verify permissions:
 
@@ -228,6 +230,7 @@ common causes are:
 - `APP_SECRET_KEY` still set to the default placeholder
 - Missing or invalid `YOUTUBE_API_KEY` (the app validates it at startup)
 - Missing or wrong `OPENAI_API_KEY` / other provider key
+- `WEBSHARE_PROXY_USERNAME` set without `WEBSHARE_PROXY_PASSWORD` (or vice versa) — the app rejects this half-configured state at startup with a clear error
 - Python import error (check `journalctl`)
 
 ---

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -14,6 +14,7 @@ VidSense is designed to run on a single VM behind a TLS reverse proxy. The [`dep
 7. **Firewall** — allow ports **443** (and **80** for ACME). Restrict SSH source IPs, use key-only auth. Do not expose port 8000.
 8. **Non-root service user** — copy [`deploy/vidsense.service`](../deploy/vidsense.service) to `/etc/systemd/system/`, create a `vidsense` user, and adjust paths. See comments in the file.
 9. **File permissions** — `chmod 600 .env`; ensure `data/` is owned by the service user and not world-readable.
+10. **Cloud VMs only — transcript proxy** — YouTube blocks unauthenticated transcript requests from datacenter IP ranges. Set `WEBSHARE_PROXY_USERNAME` and `WEBSHARE_PROXY_PASSWORD` in `.env` to route fetches through a residential proxy. See [Transcript fetching on cloud VMs](#transcript-fetching-on-cloud-vms) below for setup instructions.
 
 ## Logging
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -48,6 +48,49 @@ For programmatic API clients that need direct `/api` access without the proxy pa
 
 The sample Caddy config also includes a basic CSP, request-size limit, and upstream dial/header timeouts. Stock Caddy does not include rate limiting by default, so that is intentionally deferred for a later version.
 
+## Transcript fetching on cloud VMs
+
+YouTube blocks transcript requests from cloud-datacenter IP ranges (AWS, GCP, Azure, DigitalOcean, Hetzner, etc.). The metadata and comments APIs (authenticated with `YOUTUBE_API_KEY`) are unaffected — only the unauthenticated transcript endpoint is blocked. The fix is to route transcript requests through a residential proxy. **This is not needed for local development.**
+
+### Which Webshare plan to buy
+
+`youtube-transcript-api`'s built-in `WebshareProxyConfig` is designed for Webshare's **Residential** (rotating) proxy product. The free tier and the "Proxy Server" / "Static Residential" plans use datacenter IPs and will still be blocked by YouTube. Pricing starts around $3–6/month for the smallest residential tier. Sign up at [webshare.io](https://www.webshare.io/).
+
+### Where to find the credentials
+
+In the Webshare dashboard, navigate to **Proxy → Proxy Settings** (or **Residential → Settings**). Webshare issues a dedicated **Proxy Username** and **Proxy Password** per subaccount — these are *not* your Webshare login email and password. Copy both values verbatim.
+
+### What to put in `.env`
+
+Exactly two variables:
+
+```bash
+WEBSHARE_PROXY_USERNAME=<from Webshare dashboard>
+WEBSHARE_PROXY_PASSWORD=<from Webshare dashboard>
+```
+
+Endpoint defaults (`p.webshare.io:80`, rotation enabled) are applied automatically by `WebshareProxyConfig`. Do not override `domain_name` or `proxy_port` — doing so can silently route traffic through the wrong Webshare product.
+
+The app validates at startup that either both or neither of the two vars are set. Setting exactly one triggers a clear error.
+
+### Optional tuning (not wired, but the knobs exist)
+
+If you later want to constrain exit countries (some YouTube videos are geo-restricted) or tune retries, `WebshareProxyConfig` also accepts `filter_ip_locations=["US", "CA", "GB"]` and `retries_when_blocked=N` (default 10). Adding these is a one-line change in [`app/services/youtube.py`](../app/services/youtube.py).
+
+### How to verify before restart
+
+From the VM, confirm the proxy works independently of the app:
+
+```bash
+export WEBSHARE_PROXY_USERNAME='<from Webshare dashboard>'
+export WEBSHARE_PROXY_PASSWORD='<from Webshare dashboard>'
+curl --proxy-user "${WEBSHARE_PROXY_USERNAME}-rotate:${WEBSHARE_PROXY_PASSWORD}" \
+  -x http://p.webshare.io:80 \
+  https://api.ipify.org
+```
+
+A successful response prints a residential-looking IP that is *not* the VM's own IP. If `curl` hangs, returns a 407, or prints the VM's IP, the credentials or plan type are wrong — fix that before restarting the service.
+
 ## Deployment files
 
 | File | Purpose |

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -579,9 +579,13 @@ class TestAsyncOffload:
     async def test_fetch_transcript_runs_in_thread(self):
         with (
             patch("app.services.youtube.extract_video_id", return_value="FAKE_ID"),
-            patch("app.services.youtube._get_cached_video", new_callable=AsyncMock, return_value=None),
+            patch(
+                "app.services.youtube._get_cached_video", new_callable=AsyncMock, return_value=None
+            ),
             patch("app.services.youtube._fetch_metadata", new_callable=AsyncMock) as mock_meta,
-            patch("app.services.youtube.asyncio.to_thread", new_callable=AsyncMock) as mock_to_thread,
+            patch(
+                "app.services.youtube.asyncio.to_thread", new_callable=AsyncMock
+            ) as mock_to_thread,
         ):
             mock_meta.return_value = {
                 "title": "T",

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -4,12 +4,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
-from youtube_transcript_api import NoTranscriptFound
+from pydantic import ValidationError
+from youtube_transcript_api import IpBlocked, NoTranscriptFound, RequestBlocked
 
+from app.config import Settings
 from app.models.db import TranscriptSourceType
 from app.models.schemas import IngestionError
 from app.services.youtube import (
     _build_raw_text,
+    _build_transcript_api,
     _detect_language,
     _fetch_metadata,
     _fetch_top_comments,
@@ -446,3 +449,166 @@ class TestFetchTranscriptEnglishVariants:
         assert not hasattr(result, "error_code"), f"Expected success, got {result}"
         _, _, lang = result
         assert lang == "en"
+
+
+# ---------------------------------------------------------------------------
+# Webshare proxy configuration
+# ---------------------------------------------------------------------------
+
+_SETTINGS_DEFAULTS = {
+    "app_secret_key": "test-secret-not-placeholder",
+    "youtube_api_key": "test-yt-api-key-not-real",
+}
+
+
+class TestWebshareSettings:
+    """Settings validation for Webshare proxy credentials."""
+
+    def test_neither_set_is_valid(self):
+        s = Settings(**_SETTINGS_DEFAULTS)
+        assert s.webshare_proxy_enabled is False
+
+    def test_both_set_is_valid(self):
+        s = Settings(
+            webshare_proxy_username="user",
+            webshare_proxy_password="pass",
+            **_SETTINGS_DEFAULTS,
+        )
+        assert s.webshare_proxy_enabled is True
+
+    def test_only_username_raises(self):
+        with pytest.raises(ValidationError, match="WEBSHARE_PROXY_PASSWORD"):
+            Settings(webshare_proxy_username="user", **_SETTINGS_DEFAULTS)
+
+    def test_only_password_raises(self):
+        with pytest.raises(ValidationError, match="WEBSHARE_PROXY_USERNAME"):
+            Settings(webshare_proxy_password="pass", **_SETTINGS_DEFAULTS)
+
+
+class TestBuildTranscriptApi:
+    """_build_transcript_api returns the right client depending on settings."""
+
+    def test_direct_when_no_creds(self):
+        """No Webshare creds -> vanilla YouTubeTranscriptApi (no proxy)."""
+        import app.services.youtube as yt_mod
+
+        fake = MagicMock()
+        fake.webshare_proxy_enabled = False
+        with patch.object(yt_mod, "settings", fake):
+            api = _build_transcript_api()
+        assert api._fetcher._proxy_config is None
+
+    def test_webshare_when_creds_set(self):
+        """Both Webshare creds -> WebshareProxyConfig attached."""
+        from youtube_transcript_api.proxies import WebshareProxyConfig
+
+        import app.services.youtube as yt_mod
+
+        fake = MagicMock()
+        fake.webshare_proxy_enabled = True
+        fake.webshare_proxy_username = "u"
+        fake.webshare_proxy_password = "p"
+        with patch.object(yt_mod, "settings", fake):
+            api = _build_transcript_api()
+        assert isinstance(api._fetcher._proxy_config, WebshareProxyConfig)
+
+
+# ---------------------------------------------------------------------------
+# IP-block error mapping
+# ---------------------------------------------------------------------------
+
+
+class TestIpBlockErrorMapping:
+    """RequestBlocked / IpBlocked map to TRANSCRIPT_IP_BLOCKED in both network phases."""
+
+    @patch("app.services.youtube._build_transcript_api")
+    def test_request_blocked_on_list(self, mock_build):
+        mock_build.return_value.list.side_effect = RequestBlocked("FAKE_ID")
+        result = _fetch_transcript("FAKE_ID")
+        assert isinstance(result, IngestionError)
+        assert result.error_code == "TRANSCRIPT_IP_BLOCKED"
+        assert result.recoverable is True
+
+    @patch("app.services.youtube._build_transcript_api")
+    def test_ip_blocked_on_list(self, mock_build):
+        mock_build.return_value.list.side_effect = IpBlocked("FAKE_ID")
+        result = _fetch_transcript("FAKE_ID")
+        assert isinstance(result, IngestionError)
+        assert result.error_code == "TRANSCRIPT_IP_BLOCKED"
+        assert result.recoverable is True
+
+    @patch("app.services.youtube._build_transcript_api")
+    def test_request_blocked_on_fetch(self, mock_build):
+        """IP block during transcript.fetch() (inside _to_segments) is also caught."""
+        t_en = _make_transcript("en", is_generated=False)
+        t_en.fetch.side_effect = RequestBlocked("FAKE_ID")
+
+        transcript_list = MagicMock()
+        transcript_list.find_manually_created_transcript.return_value = t_en
+        mock_build.return_value.list.return_value = transcript_list
+
+        result = _fetch_transcript("FAKE_ID")
+        assert isinstance(result, IngestionError)
+        assert result.error_code == "TRANSCRIPT_IP_BLOCKED"
+
+    @patch("app.services.youtube._build_transcript_api")
+    def test_generic_exception_on_fetch_returns_fetch_failed(self, mock_build):
+        """A non-IP-block exception during transcript.fetch() returns TRANSCRIPT_FETCH_FAILED."""
+        t_en = _make_transcript("en", is_generated=False)
+        t_en.fetch.side_effect = RuntimeError("network timeout")
+
+        transcript_list = MagicMock()
+        transcript_list.find_manually_created_transcript.return_value = t_en
+        mock_build.return_value.list.return_value = transcript_list
+
+        result = _fetch_transcript("FAKE_ID")
+        assert isinstance(result, IngestionError)
+        assert result.error_code == "TRANSCRIPT_FETCH_FAILED"
+        assert result.recoverable is True
+
+
+# ---------------------------------------------------------------------------
+# asyncio.to_thread offload
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncOffload:
+    """ingest_video offloads _fetch_transcript to a worker thread."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_transcript_runs_in_thread(self):
+        with (
+            patch("app.services.youtube.extract_video_id", return_value="FAKE_ID"),
+            patch("app.services.youtube._get_cached_video", new_callable=AsyncMock, return_value=None),
+            patch("app.services.youtube._fetch_metadata", new_callable=AsyncMock) as mock_meta,
+            patch("app.services.youtube.asyncio.to_thread", new_callable=AsyncMock) as mock_to_thread,
+        ):
+            mock_meta.return_value = {
+                "title": "T",
+                "description": "",
+                "thumbnail": None,
+                "channel": "C",
+                "channel_url": None,
+                "upload_date": None,
+                "duration": 60,
+                "view_count": None,
+                "like_count": None,
+                "tags": [],
+                "category": None,
+                "language": "en",
+            }
+            mock_to_thread.return_value = IngestionError(
+                error_code="TRANSCRIPT_FETCH_FAILED",
+                message="test",
+                recoverable=True,
+            )
+
+            from app.services.youtube import _fetch_transcript, ingest_video
+
+            session = AsyncMock()
+            await ingest_video("https://youtube.com/watch?v=FAKE_ID", session)
+
+            mock_to_thread.assert_awaited_once()
+            args = mock_to_thread.call_args.args
+            assert args[0] is _fetch_transcript
+            assert args[1] == "FAKE_ID"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes YouTube ingestion’s transcript-fetch path (proxy routing, new error code, and thread offload), which can affect core ingestion reliability/performance if misconfigured or if library internals change.
> 
> **Overview**
> Adds optional Webshare residential-proxy support for transcript fetching (new `WEBSHARE_PROXY_USERNAME`/`WEBSHARE_PROXY_PASSWORD` settings with fail-fast validation) and routes transcript retrieval through a new `_build_transcript_api()` seam.
> 
> Makes transcript ingestion more robust on cloud VMs by mapping `RequestBlocked`/`IpBlocked` to a new `TRANSCRIPT_IP_BLOCKED` error (surfaced in the UI), and offloads the synchronous transcript fetch from `ingest_video` to a worker thread via `asyncio.to_thread`.
> 
> Updates docs (`README.md`, `docs/deployment*.md`, `.env.example`) and adds unit tests covering settings validation, provider selection, IP-block mapping, and the `to_thread` call path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3afcd6b8998845457811e5716b8f3b07ef28ebb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->