### PR TITLE
YouTube API migration follow-up hardening (closes #23)

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -45,7 +45,7 @@ async def _add_missing_columns(conn) -> None:
         ("videos", "channel_name", "VARCHAR(256)"),
         ("videos", "channel_url", "VARCHAR(512)"),
         ("videos", "description", "TEXT"),
-        ("videos", "upload_date", "VARCHAR(20)"),
+        ("videos", "upload_date", "VARCHAR(32)"),
         ("videos", "view_count", "INTEGER"),
         ("videos", "like_count", "INTEGER"),
         ("videos", "tags_json", "TEXT"),

--- a/app/models/db.py
+++ b/app/models/db.py
@@ -48,7 +48,10 @@ class Video(Base):
     channel_name: Mapped[str | None] = mapped_column(String(256))
     channel_url: Mapped[str | None] = mapped_column(String(512))
     description: Mapped[str | None] = mapped_column(Text)
-    upload_date: Mapped[str | None] = mapped_column(String(20))
+    # 32 chars (not 20) to accommodate millisecond-precision publishedAt values
+    # like "2024-06-15T10:30:00.123Z" that YouTube has historically returned.
+    # Bare ISO 8601 ("YYYY-MM-DDTHH:MM:SSZ") is exactly 20 chars with no slack.
+    upload_date: Mapped[str | None] = mapped_column(String(32))
     view_count: Mapped[int | None] = mapped_column(Integer)
     like_count: Mapped[int | None] = mapped_column(Integer)
     tags_json: Mapped[str | None] = mapped_column(Text)

--- a/app/services/youtube.py
+++ b/app/services/youtube.py
@@ -128,7 +128,10 @@ _CATEGORY_MAP: dict[str, str] = {
     "44": "Trailers",
 }
 
-_ISO_DURATION_RE = re.compile(r"^P(?:(\d+)D)?T?(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$")
+# Require the T designator before any time component and reject matches where no
+# component captured at all, so malformed inputs like "P", "PT", or "P1H"
+# (missing T) fall through to None instead of silently parsing to 0.
+_ISO_DURATION_RE = re.compile(r"^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$")
 
 
 def _parse_iso8601_duration(iso_str: str) -> int | None:
@@ -136,7 +139,7 @@ def _parse_iso8601_duration(iso_str: str) -> int | None:
     if not iso_str:
         return None
     m = _ISO_DURATION_RE.match(iso_str)
-    if not m:
+    if not m or not any(m.groups()):
         return None
     days = int(m.group(1) or 0)
     hours = int(m.group(2) or 0)
@@ -245,8 +248,28 @@ async def _fetch_top_comments(video_id: str) -> list[dict[str, str]] | None:
             resp = await client.get(f"{_YT_API_BASE}/commentThreads", params=params)
             resp.raise_for_status()
             data = resp.json()
-    except Exception:
-        logger.debug("Comments fetch failed for video %s (best-effort, skipping)", video_id)
+    except httpx.HTTPStatusError as exc:
+        status = exc.response.status_code
+        # 403 is the documented "commentsDisabled" path for this endpoint —
+        # genuinely silent and expected. All other statuses (401/404/429/5xx)
+        # indicate misconfiguration, quota exhaustion, or infrastructure issues
+        # that operators need to see in journald even though the UX stays
+        # best-effort.
+        if status == 403:
+            logger.debug("Comments disabled for video %s, skipping", video_id)
+        else:
+            logger.warning(
+                "Comments fetch HTTP %d for video %s (best-effort, skipping)",
+                status,
+                video_id,
+            )
+        return None
+    except Exception as exc:
+        logger.warning(
+            "Comments fetch failed for video %s (best-effort, skipping): %s",
+            video_id,
+            exc,
+        )
         return None
 
     comments: list[dict[str, str]] = []
@@ -510,6 +533,17 @@ async def ingest_video(
     comments = await _fetch_top_comments(video_id)
 
     # 7. Persist
+    #
+    # Cache-hit backfill behaviour (intentional, not a bug):
+    # If `existing_video` is set we reuse it verbatim and do NOT copy any
+    # freshly-fetched fields (upload_date, tags, comments, category, ...) onto
+    # it. This path is only reached for legacy yt-dlp rows whose transcript was
+    # evicted — their `upload_date` keeps the old `YYYYMMDD` shape and
+    # tags_json / top_comments_json / category stay NULL. Templates and prompts
+    # already tolerate NULL here; see the "Risks" section of the YouTube API
+    # migration plan. If we ever want to backfill these columns on re-ingest,
+    # do it behind an explicit settings flag rather than silently overwriting
+    # cached rows.
     tags = metadata.get("tags", [])
     video = existing_video or Video(
         youtube_id=video_id,

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -92,6 +92,20 @@ curl --proxy-user "${WEBSHARE_PROXY_USERNAME}-rotate:${WEBSHARE_PROXY_PASSWORD}"
 
 A successful response prints a residential-looking IP that is *not* the VM's own IP. If `curl` hangs, returns a 407, or prints the VM's IP, the credentials or plan type are wrong — fix that before restarting the service.
 
+## Schema migrations
+
+VidSense uses SQLite by default and applies additive schema changes at startup via `_add_missing_columns` in [`app/database.py`](../app/database.py). SQLite ignores `VARCHAR(n)` widths, so column-width changes on the default deployment are no-ops and need no manual step.
+
+**Non-SQLite deployments (Postgres, MySQL, etc.)** enforce declared column widths and do not pick up width changes from `_add_missing_columns` (it only handles missing columns). If you operate such a deployment, run the following migration before restarting on a version that includes issue #23:
+
+```sql
+-- videos.upload_date widened from VARCHAR(20) to VARCHAR(32) to accommodate
+-- millisecond-precision YouTube publishedAt values (e.g. "2024-06-15T10:30:00.123Z").
+ALTER TABLE videos ALTER COLUMN upload_date TYPE VARCHAR(32);
+```
+
+The change is backwards-compatible: existing 20-char values continue to fit, and no data migration is needed.
+
 ## Deployment files
 
 | File | Purpose |

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -110,6 +110,19 @@ class TestParseIso8601Duration:
     def test_none_input(self):
         assert _parse_iso8601_duration(None) is None
 
+    def test_bare_p_returns_none(self):
+        # "P" alone has no components — must not silently parse to 0.
+        assert _parse_iso8601_duration("P") is None
+
+    def test_bare_pt_returns_none(self):
+        # "PT" has the time designator but no components — must be None.
+        assert _parse_iso8601_duration("PT") is None
+
+    def test_hour_without_t_designator_returns_none(self):
+        # "P1H" is not valid ISO 8601 (missing T). Previously the loose regex
+        # treated the T as optional and this parsed to 3600 seconds.
+        assert _parse_iso8601_duration("P1H") is None
+
 
 # ---------------------------------------------------------------------------
 # Language detection (updated for API v3 field names)
@@ -318,7 +331,7 @@ class TestFetchTopComments:
         assert result[0]["text"] == "Great video!"
 
     @pytest.mark.asyncio
-    async def test_comments_disabled_returns_none(self):
+    async def test_comments_disabled_returns_none(self, caplog):
         error_resp = httpx.Response(
             status_code=403,
             json={"error": {"errors": [{"reason": "commentsDisabled"}]}},
@@ -330,9 +343,54 @@ class TestFetchTopComments:
             mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
-            result = await _fetch_top_comments("no_comments")
+            with caplog.at_level("WARNING", logger="app.services.youtube"):
+                result = await _fetch_top_comments("no_comments")
 
         assert result is None
+        # 403 is the "silent" commentsDisabled case — must not log at WARNING.
+        assert not [r for r in caplog.records if r.name == "app.services.youtube"], (
+            "403 commentsDisabled should not produce a WARNING"
+        )
+
+    @pytest.mark.asyncio
+    async def test_server_error_logs_warning(self, caplog):
+        # Non-403 HTTP errors (quota key misconfig, 5xx, rate-limit, etc.)
+        # should surface as WARNING so operators can see them in journald.
+        error_resp = httpx.Response(
+            status_code=500,
+            json={"error": {"message": "internal error"}},
+            request=httpx.Request("GET", "https://test"),
+        )
+        with patch("app.services.youtube.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=error_resp)
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with caplog.at_level("WARNING", logger="app.services.youtube"):
+                result = await _fetch_top_comments("boom_id")
+
+        assert result is None
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert warnings, "Non-403 HTTP errors must emit a WARNING"
+        assert "500" in warnings[0].getMessage()
+        assert "boom_id" in warnings[0].getMessage()
+
+    @pytest.mark.asyncio
+    async def test_network_error_logs_warning(self, caplog):
+        with patch("app.services.youtube.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(side_effect=httpx.ConnectError("down"))
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with caplog.at_level("WARNING", logger="app.services.youtube"):
+                result = await _fetch_top_comments("net_fail")
+
+        assert result is None
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert warnings, "Network errors must emit a WARNING"
+        assert "net_fail" in warnings[0].getMessage()
 
     @pytest.mark.asyncio
     async def test_truncates_long_comments(self):


### PR DESCRIPTION
## Summary

Executes the four in-scope hardening items from #23 — follow-ups to the YouTube Data API v3 migration. None of these fix a live bug; all are forward-looking robustness improvements called out in the post-migration PR review. Task #5 (event-loop offload) is intentionally out of scope per the issue.

### Changes

- **Task 1 — `_parse_iso8601_duration` regex tightened** (`app/services/youtube.py`). `"P"`, `"PT"`, and `"P1H"` now correctly return `None` instead of silently parsing to `0`. The `T` designator is required before any time component, and matches where no group captured anything are rejected. Three new negative-case tests.
- **Task 2 — selective log-level routing in `_fetch_top_comments`** (`app/services/youtube.py`). HTTP 403 (commentsDisabled) stays at DEBUG because the "skip silently" UX is correct for that documented case. Every other failure (401/404/429/5xx/network/generic) now logs at WARNING so operators get a journald signal when a key is misconfigured, quota is exhausted, or YouTube is returning transient 5xx. The best-effort UX is unchanged — comments still skip on error. Two new tests cover the non-403 branches and the existing "403 is silent" test was tightened to assert no WARNING is emitted.
- **Task 3 — `videos.upload_date` widened `VARCHAR(20)` → `VARCHAR(32)`** (`app/models/db.py`, `app/database.py`). ISO 8601 `YYYY-MM-DDTHH:MM:SSZ` is exactly 20 chars with no slack; millisecond-precision `publishedAt` values YouTube has historically returned in some edge cases (`2024-06-15T10:30:00.123Z` = 24 chars) no longer risk truncation. See the docs section below for non-SQLite deployments.
- **Task 4 — document cache-hit backfill behaviour in `ingest_video`** (`app/services/youtube.py`). Multi-line comment explaining that legacy yt-dlp Video rows reached via the cache path are intentionally left unmodified (keeping their old `YYYYMMDD` `upload_date` and `NULL` tags / comments / category). This matches the migration plan's risk acceptance — the code is just easy to misread otherwise.

### Non-SQLite deployment note (Task 3)

SQLite ignores `VARCHAR(n)` widths, so the default deployment migrates at runtime with no manual step. Postgres / MySQL deployments enforce declared widths and do **not** pick up width changes from `_add_missing_columns` (it only adds missing columns). Documented in `docs/deployment.md` under a new "Schema migrations" section with the one-liner:

```sql
ALTER TABLE videos ALTER COLUMN upload_date TYPE VARCHAR(32);
```

The change is backwards-compatible — existing 20-char values continue to fit, no data migration is needed.

## Acceptance criteria (from #23)

- [x] #1: regex tightened + 3 new negative-case tests
- [x] #2: selective log-level routing in `_fetch_top_comments` (+ 2 new tests, existing test tightened)
- [x] #3: `upload_date` column widened to 32 chars, non-SQLite migration step documented in `docs/deployment.md`
- [x] #4: explanatory comment added in `ingest_video`
- [x] Full test suite (`uv run pytest`) green — 222 passed

## Test plan

- [x] `uv run pytest` — 222 passed, 0 failed
- [x] `uv run ruff check app/ tests/` — all checks passed
- [x] `uv run ruff format --check app/ tests/` — all formatted
- [x] Spot-check: ingest a fresh YouTube URL, confirm metadata still populates (duration, tags, comments, category, upload_date)
- [ ] Spot-check: trigger a 5xx from the comments endpoint (or temporarily use an invalid key) and confirm a WARNING appears in logs while ingestion still succeeds

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to a schema width change (`videos.upload_date`) that may require manual migration on non-SQLite databases and adjusted logging behavior that could affect ops alerting/noise; runtime behavior remains best-effort on comment failures.
> 
> **Overview**
> Improves robustness of the YouTube Data API v3 ingestion by making `_parse_iso8601_duration` reject malformed inputs (e.g. `P`, `PT`, `P1H`) instead of silently parsing them.
> 
> Adjusts `_fetch_top_comments` error handling to keep the known `403 commentsDisabled` case *silent* (DEBUG) while surfacing other HTTP/network failures at WARNING, with new tests covering these branches.
> 
> Widens `videos.upload_date` from `VARCHAR(20)` to `VARCHAR(32)` (DB model + startup SQLite migration list) to accommodate millisecond-precision `publishedAt` values, and documents the required manual migration step for non-SQLite deployments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3f0bfe46fdb9b6ee7edd0b39fd2d7c05eeaefa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->